### PR TITLE
Added warning about stopped apps to the confirmation dialog

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/dialogs/BackupDialogFragment.java
+++ b/app/src/main/java/com/machiav3lli/backup/dialogs/BackupDialogFragment.java
@@ -28,6 +28,7 @@ import com.machiav3lli.backup.ActionListener;
 import com.machiav3lli.backup.R;
 import com.machiav3lli.backup.handler.BackupRestoreHelper;
 import com.machiav3lli.backup.handler.action.BaseAppAction;
+import com.machiav3lli.backup.utils.PrefUtils;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -48,8 +49,11 @@ public class BackupDialogFragment extends DialogFragment {
         final String packageLabel = arguments.getString("packageLabel");
 
         AlertDialog.Builder builder = new AlertDialog.Builder(this.getActivity())
-            .setTitle(packageLabel)
-            .setMessage(R.string.backup);
+                .setTitle(this.getContext().getString(R.string.backup) + ' ' + packageLabel);
+
+        if (PrefUtils.isKillBeforeActionEnabled(this.getContext())) {
+            builder.setMessage(R.string.msg_appkill_warning);
+        }
 
         boolean showApkBtn = pi != null && !pi.applicationInfo.sourceDir.isEmpty();
         BackupRestoreHelper.ActionType actionType = BackupRestoreHelper.ActionType.BACKUP;

--- a/app/src/main/java/com/machiav3lli/backup/dialogs/BatchConfirmDialog.java
+++ b/app/src/main/java/com/machiav3lli/backup/dialogs/BatchConfirmDialog.java
@@ -27,6 +27,7 @@ import androidx.fragment.app.DialogFragment;
 import com.machiav3lli.backup.Constants;
 import com.machiav3lli.backup.R;
 import com.machiav3lli.backup.items.AppMetaInfo;
+import com.machiav3lli.backup.utils.PrefUtils;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -45,6 +46,11 @@ public class BatchConfirmDialog extends DialogFragment {
         String title = backupBoolean ? getString(R.string.backupConfirmation) : getString(R.string.restoreConfirmation);
         StringBuilder message = new StringBuilder();
         assert selectedList != null;
+        if (PrefUtils.isKillBeforeActionEnabled(this.getContext())) {
+            message.append(this.getContext().getString(R.string.msg_appkill_warning));
+            message.append("\n\n");
+        }
+
         for (AppMetaInfo item : selectedList)
             message.append(item.getPackageLabel()).append("\n");
         AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity());

--- a/app/src/main/java/com/machiav3lli/backup/fragments/AppSheet.java
+++ b/app/src/main/java/com/machiav3lli/backup/fragments/AppSheet.java
@@ -286,6 +286,7 @@ public class AppSheet extends BottomSheetDialogFragment implements ActionListene
         binding.backup.setOnClickListener(v -> {
             Bundle arguments = new Bundle();
             arguments.putParcelable("package", this.app.getPackageInfo());
+            arguments.putString("packageLabel", this.app.getAppInfo().getPackageLabel());
             BackupDialogFragment dialog = new BackupDialogFragment(fragment);
             dialog.setArguments(arguments);
             dialog.show(requireActivity().getSupportFragmentManager(), "backupDialog");

--- a/app/src/main/java/com/machiav3lli/backup/handler/action/BackupAppAction.java
+++ b/app/src/main/java/com/machiav3lli/backup/handler/action/BackupAppAction.java
@@ -75,7 +75,7 @@ public class BackupAppAction extends BaseAppAction {
         }
         BackupBuilder backupBuilder = new BackupBuilder(this.getContext(), app.getAppInfo(), appBackupRootUri);
         StorageFile backupDir = backupBuilder.getBackupPath();
-        if (PrefUtils.getDefaultSharedPreferences(this.getContext()).getBoolean(Constants.PREFS_KILLBEFOREACTION, true)) {
+        if (PrefUtils.isKillBeforeActionEnabled(this.getContext())) {
             Log.d(BackupAppAction.TAG, "Killing package to avoid file changes during backup");
             this.killPackage(app.getPackageName());
         }

--- a/app/src/main/java/com/machiav3lli/backup/handler/action/RestoreAppAction.java
+++ b/app/src/main/java/com/machiav3lli/backup/handler/action/RestoreAppAction.java
@@ -67,7 +67,7 @@ public class RestoreAppAction extends BaseAppAction {
     public ActionResult run(AppInfoX app, BackupProperties backupProperties, Uri backupLocation, int backupMode) {
         Log.i(RestoreAppAction.TAG, String.format("Restoring up: %s [%s]", app.getPackageName(), app.getAppInfo().getPackageLabel()));
         try {
-            if (PrefUtils.getDefaultSharedPreferences(this.getContext()).getBoolean(Constants.PREFS_KILLBEFOREACTION, true)) {
+            if (PrefUtils.isKillBeforeActionEnabled(this.getContext())) {
                 Log.d(RestoreAppAction.TAG, "Killing package to avoid file changes during restore");
                 this.killPackage(app.getPackageName());
             }

--- a/app/src/main/java/com/machiav3lli/backup/utils/PrefUtils.java
+++ b/app/src/main/java/com/machiav3lli/backup/utils/PrefUtils.java
@@ -164,6 +164,10 @@ public class PrefUtils {
         return prefs.getBoolean(Constants.PREFS_IGNORE_BATTERY_OPTIMIZATION, false) || powerManager.isIgnoringBatteryOptimizations(context.getPackageName());
     }
 
+    public static boolean isKillBeforeActionEnabled(Context context) {
+        return PrefUtils.getDefaultSharedPreferences(context).getBoolean(Constants.PREFS_KILLBEFOREACTION, true);
+    }
+
     public static class StorageLocationNotConfiguredException extends Exception {
 
         public StorageLocationNotConfiguredException() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -209,4 +209,5 @@
     <string name="intro_permission_storage_location">The app needs a backup location to store the backups. The app may need a few gigabytes of storage for a full backup and is querying the filesystem a lot. Please keep that in mind when choosing network based storage locations.</string>
     <string name="intro_permission_usageaccess">The app needs this permission to be able to check the stats and sizes of data and cache of your apps.</string>
     <string name="intro_permission_batteryoptimization">The app can face some problems doing scheduled backups on some ROMs that adopt an aggressive battery optimizations e.g. MIUI, but even on vanilla AOSP such a problem can happen.</string>
+    <string name="msg_appkill_warning">The selected App(s) will be stopped. Please make sure, that you either restart your device after processing or open apps like your alarm clock or calendar afterwards to avoid missing important notifications. Your keyboard or launcher might be reset to the default app for it.</string>
 </resources>


### PR DESCRIPTION
Users should be informed, that OABX is going to stop their apps and therefore also the services that would trigger alarms. Apps like alarm clocks or calendars are examples.

![Screenshot_1601741486](https://user-images.githubusercontent.com/5569743/94996621-06b27200-05a6-11eb-9d60-078443b6c188.png)


![Screenshot_1601742468](https://user-images.githubusercontent.com/5569743/94996636-25b10400-05a6-11eb-8808-8a9fefbbc9bd.png)
