### PR TITLE
AppInfoX: make Abstraction more complete, mostly eliminate use of getAppInfo()

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/activities/MainActivityX.java
+++ b/app/src/main/java/com/machiav3lli/backup/activities/MainActivityX.java
@@ -375,8 +375,8 @@ public class MainActivityX extends BaseActivity implements BatchConfirmDialog.Co
             String message = "(" + i + '/' + total + ')';
             String title = (this.backupBoolean ? this.getString(R.string.backupProgress) : this.getString(R.string.restoreProgress))
                     + " (" + i + '/' + total + ')';
-            NotificationHelper.showNotification(this, MainActivityX.class, notificationId, title, app.getAppInfo().getPackageLabel(), false);
-            this.handleMessages.setMessage(app.getAppInfo().getPackageLabel(), message);
+            NotificationHelper.showNotification(this, MainActivityX.class, notificationId, title, app.getPackageLabel(), false);
+            this.handleMessages.setMessage(app.getPackageLabel(), message);
             int mode = checkSelectedMode();
             final BackupRestoreHelper backupRestoreHelper = new BackupRestoreHelper();
             ActionResult result;

--- a/app/src/main/java/com/machiav3lli/backup/dialogs/BlacklistDialogFragment.java
+++ b/app/src/main/java/com/machiav3lli/backup/dialogs/BlacklistDialogFragment.java
@@ -60,10 +60,10 @@ public class BlacklistDialogFragment extends DialogFragment {
             assert blacklistedPackages != null;
             boolean b1 = blacklistedPackages.contains(appInfo1.getPackageName());
             boolean b2 = blacklistedPackages.contains(appInfo2.getPackageName());
-            return (b1 != b2) ? (b1 ? -1 : 1) : appInfo1.getAppInfo().getPackageLabel().compareToIgnoreCase(appInfo2.getAppInfo().getPackageLabel());
+            return (b1 != b2) ? (b1 ? -1 : 1) : appInfo1.getPackageLabel().compareToIgnoreCase(appInfo2.getPackageLabel());
         });
         for (AppInfoX appInfo : appInfoList) {
-            labels.add(appInfo.getAppInfo().getPackageLabel());
+            labels.add(appInfo.getPackageLabel());
             assert blacklistedPackages != null;
             if (blacklistedPackages.contains(appInfo.getPackageName())) {
                 checkedPackages[i] = true;

--- a/app/src/main/java/com/machiav3lli/backup/fragments/BatchFragment.java
+++ b/app/src/main/java/com/machiav3lli/backup/fragments/BatchFragment.java
@@ -70,7 +70,7 @@ public class BatchFragment extends Fragment implements SearchViewController {
             public boolean onQueryTextChange(String newText) {
                 requireMainActivity().getBatchItemAdapter().filter(newText);
                 requireMainActivity().getBatchItemAdapter().getItemFilter().setFilterPredicate((mainItemX, charSequence) ->
-                        mainItemX.getApp().getAppInfo().getPackageLabel().toLowerCase().contains(String.valueOf(charSequence).toLowerCase())
+                        mainItemX.getApp().getPackageLabel().toLowerCase().contains(String.valueOf(charSequence).toLowerCase())
                                 || mainItemX.getApp().getPackageName().toLowerCase().contains(String.valueOf(charSequence).toLowerCase()));
                 return true;
             }
@@ -79,7 +79,7 @@ public class BatchFragment extends Fragment implements SearchViewController {
             public boolean onQueryTextSubmit(String query) {
                 requireMainActivity().getBatchItemAdapter().filter(query);
                 requireMainActivity().getBatchItemAdapter().getItemFilter().setFilterPredicate((mainItemX, charSequence) ->
-                        mainItemX.getApp().getAppInfo().getPackageLabel().toLowerCase().contains(String.valueOf(charSequence).toLowerCase())
+                        mainItemX.getApp().getPackageLabel().toLowerCase().contains(String.valueOf(charSequence).toLowerCase())
                                 || mainItemX.getApp().getPackageName().toLowerCase().contains(String.valueOf(charSequence).toLowerCase()));
                 return true;
             }

--- a/app/src/main/java/com/machiav3lli/backup/fragments/MainFragment.java
+++ b/app/src/main/java/com/machiav3lli/backup/fragments/MainFragment.java
@@ -72,8 +72,8 @@ public class MainFragment extends Fragment implements SearchViewController {
             public boolean onQueryTextChange(String newText) {
                 requireMainActivity().getMainItemAdapter().filter(newText);
                 requireMainActivity().getMainItemAdapter().getItemFilter().setFilterPredicate((mainItemX, charSequence) ->
-                        mainItemX.getApp().getAppInfo().getPackageLabel().toLowerCase().contains(String.valueOf(charSequence).toLowerCase())
-                                || mainItemX.getApp().getAppInfo().getPackageLabel().toLowerCase().contains(String.valueOf(charSequence).toLowerCase()));
+                        mainItemX.getApp().getPackageLabel().toLowerCase().contains(String.valueOf(charSequence).toLowerCase())
+                                || mainItemX.getApp().getPackageLabel().toLowerCase().contains(String.valueOf(charSequence).toLowerCase()));
                 return true;
             }
 
@@ -81,7 +81,7 @@ public class MainFragment extends Fragment implements SearchViewController {
             public boolean onQueryTextSubmit(String query) {
                 requireMainActivity().getMainItemAdapter().filter(query);
                 requireMainActivity().getMainItemAdapter().getItemFilter().setFilterPredicate((mainItemX, charSequence) ->
-                        mainItemX.getApp().getAppInfo().getPackageLabel().toLowerCase().contains(String.valueOf(charSequence).toLowerCase())
+                        mainItemX.getApp().getPackageLabel().toLowerCase().contains(String.valueOf(charSequence).toLowerCase())
                                 || mainItemX.getApp().getPackageName().toLowerCase().contains(String.valueOf(charSequence).toLowerCase()));
                 return true;
             }

--- a/app/src/main/java/com/machiav3lli/backup/fragments/PrefsFragment.java
+++ b/app/src/main/java/com/machiav3lli/backup/fragments/PrefsFragment.java
@@ -188,7 +188,7 @@ public class PrefsFragment extends PreferenceFragmentCompat {
             for (AppInfoX appInfo : appInfoList) {
                 if (!appInfo.isInstalled()) {
                     deleteList.add(appInfo);
-                    message.append(appInfo.getAppInfo().getPackageLabel()).append("\n");
+                    message.append(appInfo.getPackageLabel()).append("\n");
                 }
             }
         }
@@ -254,8 +254,8 @@ public class PrefsFragment extends PreferenceFragmentCompat {
     public void deleteBackups(List<AppInfoX> deleteList) {
         handleMessages.showMessage(getString(R.string.batchDeleteMessage), "");
         for (AppInfoX appInfo : deleteList) {
-            handleMessages.changeMessage(getString(R.string.batchDeleteMessage), appInfo.getAppInfo().getPackageLabel());
-            Log.i(TAG, "deleting backups of " + appInfo.getAppInfo().getPackageLabel());
+            handleMessages.changeMessage(getString(R.string.batchDeleteMessage), appInfo.getPackageLabel());
+            Log.i(TAG, "deleting backups of " + appInfo.getPackageLabel());
             appInfo.deleteAllBackups();
             appInfo.refreshBackupHistory();
         }

--- a/app/src/main/java/com/machiav3lli/backup/handler/BackupRestoreHelper.java
+++ b/app/src/main/java/com/machiav3lli/backup/handler/BackupRestoreHelper.java
@@ -50,7 +50,7 @@ public class BackupRestoreHelper {
     public ActionResult backup(Context context, ShellHandler shell, @NotNull AppInfoX app, int backupMode) {
         BackupAppAction action;
         // Select and prepare the action to use
-        if (app.getAppInfo().isSpecial()) {
+        if (app.isSpecial()) {
             if ((backupMode & BaseAppAction.MODE_APK) == BaseAppAction.MODE_APK) {
                 Log.e(BackupRestoreHelper.TAG,
                         String.format("%s: Special Backup called with MODE_APK or MODE_BOTH. Masking invalid settings.", app));
@@ -82,9 +82,9 @@ public class BackupRestoreHelper {
             Context context, AppInfoX app, BackupProperties backupProperties,
             Uri backupLocation, ShellHandler shell, int mode) {
         RestoreAppAction restoreAction;
-        if (app.getAppInfo().isSpecial()) {
+        if (app.isSpecial()) {
             restoreAction = new RestoreSpecialAction(context, shell);
-        } else if (app.getAppInfo().isSystem()) {
+        } else if (app.isSystem()) {
             restoreAction = new SystemRestoreAppAction(context, shell);
         } else {
             restoreAction = new RestoreAppAction(context, shell);

--- a/app/src/main/java/com/machiav3lli/backup/handler/SortFilterManager.java
+++ b/app/src/main/java/com/machiav3lli/backup/handler/SortFilterManager.java
@@ -34,7 +34,7 @@ import java.util.List;
 public class SortFilterManager {
 
     public static final Comparator<AppInfoX> appInfoLabelComparator = (m1, m2) ->
-            m1.getAppInfo().getPackageLabel().compareToIgnoreCase(m2.getAppInfo().getPackageLabel());
+            m1.getPackageLabel().compareToIgnoreCase(m2.getPackageLabel());
     public static final Comparator<AppInfoX> appInfoPackageNameComparator = (m1, m2) ->
             m1.getPackageName().compareToIgnoreCase(m2.getPackageName());
     public static final Comparator<AppInfoX> appDataSizeComparator = (m1, m2) ->
@@ -61,13 +61,13 @@ public class SortFilterManager {
         ArrayList<AppInfoX> nlist = new ArrayList<>(list);
         switch (filter.charAt(1)) {
             case '1':
-                for (AppInfoX item : list) if (!item.getAppInfo().isSystem()) nlist.remove(item);
+                for (AppInfoX item : list) if (!item.isSystem()) nlist.remove(item);
                 break;
             case '2':
-                for (AppInfoX item : list) if (item.getAppInfo().isSystem()) nlist.remove(item);
+                for (AppInfoX item : list) if (item.isSystem()) nlist.remove(item);
                 break;
             case '3':
-                for (AppInfoX item : list) if (!item.getAppInfo().isSpecial()) nlist.remove(item);
+                for (AppInfoX item : list) if (!item.isSpecial()) nlist.remove(item);
                 break;
             default:
                 break;
@@ -107,7 +107,7 @@ public class SortFilterManager {
                 for (AppInfoX item : list) {
                     if (!(!item.hasBackups() ||
                             (item.getLatestBackup().getBackupProperties().getVersionCode() != 0
-                                    && item.getAppInfo().getVersionCode() > item.getLatestBackup().getBackupProperties().getVersionCode()))
+                                    && item.getVersionCode() > item.getLatestBackup().getBackupProperties().getVersionCode()))
                     ) {
                         nlist.remove(item);
                     }

--- a/app/src/main/java/com/machiav3lli/backup/handler/action/BackupAppAction.java
+++ b/app/src/main/java/com/machiav3lli/backup/handler/action/BackupAppAction.java
@@ -60,7 +60,7 @@ public class BackupAppAction extends BaseAppAction {
     }
 
     public ActionResult run(AppInfoX app, int backupMode) {
-        Log.i(BackupAppAction.TAG, String.format("Backing up: %s [%s]", app.getPackageName(), app.getAppInfo().getPackageLabel()));
+        Log.i(BackupAppAction.TAG, String.format("Backing up: %s [%s]", app.getPackageName(), app.getPackageLabel()));
         Uri appBackupRootUri = null;
         try {
             appBackupRootUri = app.getBackupDir(true);

--- a/app/src/main/java/com/machiav3lli/backup/handler/action/RestoreAppAction.java
+++ b/app/src/main/java/com/machiav3lli/backup/handler/action/RestoreAppAction.java
@@ -65,7 +65,7 @@ public class RestoreAppAction extends BaseAppAction {
     }
 
     public ActionResult run(AppInfoX app, BackupProperties backupProperties, Uri backupLocation, int backupMode) {
-        Log.i(RestoreAppAction.TAG, String.format("Restoring up: %s [%s]", app.getPackageName(), app.getAppInfo().getPackageLabel()));
+        Log.i(RestoreAppAction.TAG, String.format("Restoring up: %s [%s]", app.getPackageName(), app.getPackageLabel()));
         try {
             if (PrefUtils.isKillBeforeActionEnabled(this.getContext())) {
                 Log.d(RestoreAppAction.TAG, "Killing package to avoid file changes during restore");

--- a/app/src/main/java/com/machiav3lli/backup/items/AppInfoX.java
+++ b/app/src/main/java/com/machiav3lli/backup/items/AppInfoX.java
@@ -185,6 +185,34 @@ public class AppInfoX {
         return !metaInfo.isSpecial() && (packageInfo != null && !packageInfo.applicationInfo.enabled);
     }
 
+    public boolean isSystem() {
+        return (this.packageInfo != null && metaInfo.isSystem()) || metaInfo.isSpecial();
+    }
+
+    public boolean isSpecial() {
+        return metaInfo.isSpecial();
+    }
+
+    public PackageInfo getPackageInfo() {
+        return this.packageInfo;
+    }
+
+    public String getPackageName() {
+        return this.packageName;
+    }
+
+    public String getPackageLabel() {
+        return metaInfo.getPackageLabel() != null ? metaInfo.getPackageLabel() : getPackageName();
+    }
+
+    public int getVersionCode() {
+        return metaInfo.getVersionCode();
+    }
+
+    public String getVersionName() {
+        return metaInfo.getVersionName();
+    }
+
     public boolean hasBackups() {
         return !this.backupHistory.isEmpty();
     }
@@ -194,14 +222,6 @@ public class AppInfoX {
             return this.backupHistory.get(this.backupHistory.size() - 1);
         }
         return null;
-    }
-
-    public PackageInfo getPackageInfo() {
-        return this.packageInfo;
-    }
-
-    public String getPackageName() {
-        return this.packageName;
     }
 
     public AppMetaInfo getAppInfo() {
@@ -262,7 +282,7 @@ public class AppInfoX {
 
     public boolean isUpdated() {
         return this.hasBackups()
-                && this.getLatestBackup().getBackupProperties().getVersionCode() > this.getAppInfo().getVersionCode();
+                && this.getLatestBackup().getBackupProperties().getVersionCode() > this.getVersionCode();
     }
 
     /**

--- a/app/src/main/java/com/machiav3lli/backup/items/BatchItemX.java
+++ b/app/src/main/java/com/machiav3lli/backup/items/BatchItemX.java
@@ -97,7 +97,7 @@ public class BatchItemX extends AbstractItem<BatchItemX.ViewHolder> {
             final AppInfoX app = item.getApp();
 
             this.checkbox.setChecked(item.isChecked());
-            this.label.setText(app.getAppInfo().getPackageLabel());
+            this.label.setText(app.getPackageLabel());
             this.packageName.setText(app.getPackageName());
             if (app.hasBackups()) {
                 // Todo: Find a proper way to display multiple backups. Just showing the latest for now

--- a/app/src/main/java/com/machiav3lli/backup/schedules/CustomPackageList.java
+++ b/app/src/main/java/com/machiav3lli/backup/schedules/CustomPackageList.java
@@ -69,7 +69,7 @@ public class CustomPackageList {
         ArrayList<String> list = new ArrayList<>();
         if (!appInfoList.isEmpty()) {
             for (AppInfoX appInfo : appInfoList)
-                list.add(appInfo.getAppInfo().getPackageLabel());
+                list.add(appInfo.getPackageLabel());
         }
         return list.toArray(new CharSequence[0]);
     }

--- a/app/src/main/java/com/machiav3lli/backup/schedules/HandleScheduledBackups.java
+++ b/app/src/main/java/com/machiav3lli/backup/schedules/HandleScheduledBackups.java
@@ -85,21 +85,21 @@ public class HandleScheduledBackups {
                     break;
                 case USER:
                     for (AppInfoX appInfo : list) {
-                        if (!appInfo.getAppInfo().isSystem()) {
+                        if (!appInfo.isSystem()) {
                             listToBackUp.add(appInfo);
                         }
                     }
                     break;
                 case SYSTEM:
                     for (AppInfoX appInfo : list) {
-                        if (appInfo.getAppInfo().isSystem()) {
+                        if (appInfo.isSystem()) {
                             listToBackUp.add(appInfo);
                         }
                     }
                     break;
                 case NEW_UPDATED:
                     for (AppInfoX appInfo : list) {
-                        if ((!excludeSystem || !appInfo.getAppInfo().isSystem()) && (appInfo.hasBackups() || (appInfo.getAppInfo().getVersionCode() > appInfo.getLatestBackup().getBackupProperties().getVersionCode()))) {
+                        if ((!excludeSystem || !appInfo.isSystem()) && (appInfo.hasBackups() || (appInfo.getVersionCode() > appInfo.getLatestBackup().getBackupProperties().getVersionCode()))) {
                             listToBackUp.add(appInfo);
                         }
                     }
@@ -143,7 +143,7 @@ public class HandleScheduledBackups {
                         continue;
                     }
                     String title = context.getString(R.string.backupProgress) + " (" + i + "/" + total + ")";
-                    NotificationHelper.showNotification(context, MainActivityX.class, id, title, appInfo.getAppInfo().getPackageLabel(), false);
+                    NotificationHelper.showNotification(context, MainActivityX.class, id, title, appInfo.getPackageLabel(), false);
                     final BackupRestoreHelper backupRestoreHelper = new BackupRestoreHelper();
                     ActionResult result = backupRestoreHelper.backup(context, MainActivityX.getShellHandlerInstance(), appInfo, subMode);
 

--- a/app/src/main/java/com/machiav3lli/backup/tasks/BaseTask.java
+++ b/app/src/main/java/com/machiav3lli/backup/tasks/BaseTask.java
@@ -62,7 +62,7 @@ public abstract class BaseTask extends AsyncTask<Void, Void, Integer> {
         final HandleMessages handleMessages = handleMessagesReference.get();
         final MainActivityX oAndBackupX = mainActivityXReference.get();
         if (handleMessages != null && oAndBackupX != null && !oAndBackupX.isFinishing())
-            handleMessages.showMessage(this.app.getAppInfo().getPackageLabel(), getProgressMessage(oAndBackupX, actionType));
+            handleMessages.showMessage(this.app.getPackageLabel(), getProgressMessage(oAndBackupX, actionType));
     }
 
     @Override
@@ -72,7 +72,7 @@ public abstract class BaseTask extends AsyncTask<Void, Void, Integer> {
         if (handleMessages != null && mainActivityX != null && !mainActivityX.isFinishing()) {
             handleMessages.endMessage();
             final String message = getPostExecuteMessage(mainActivityX, actionType, result);
-            NotificationHelper.showNotification(mainActivityX, MainActivityX.class, (int) System.currentTimeMillis(), this.app.getAppInfo().getPackageLabel(), message, true);
+            NotificationHelper.showNotification(mainActivityX, MainActivityX.class, (int) System.currentTimeMillis(), this.app.getPackageLabel(), message, true);
             UIUtils.showActionResult(mainActivityX, this.result, null);
             mainActivityX.refreshWithAppSheet();
         }

--- a/app/src/main/java/com/machiav3lli/backup/utils/ItemUtils.java
+++ b/app/src/main/java/com/machiav3lli/backup/utils/ItemUtils.java
@@ -17,10 +17,7 @@
  */
 package com.machiav3lli.backup.utils;
 
-import android.app.Activity;
-import android.content.Context;
 import android.content.res.ColorStateList;
-import android.content.res.Resources;
 import android.graphics.Color;
 import android.view.View;
 
@@ -28,10 +25,8 @@ import androidx.appcompat.widget.AppCompatImageView;
 import androidx.appcompat.widget.AppCompatTextView;
 import androidx.appcompat.widget.LinearLayoutCompat;
 
-import com.google.android.material.internal.ContextUtils;
 import com.machiav3lli.backup.Constants;
 import com.machiav3lli.backup.R;
-import com.machiav3lli.backup.activities.MainActivityX;
 import com.machiav3lli.backup.handler.action.BaseAppAction;
 import com.machiav3lli.backup.items.AppInfoX;
 import com.machiav3lli.backup.schedules.db.Schedule;
@@ -75,9 +70,9 @@ public final class ItemUtils {
     public static void pickSheetAppType(AppInfoX app, AppCompatTextView text) {
         int color;
         if (app.isInstalled()) {
-            if (app.getAppInfo().isSpecial()) {
+            if (app.isSpecial()) {
                 color = colorSpecial;
-            } else if (app.getAppInfo().isSystem()) {
+            } else if (app.isSystem()) {
                 color = colorSystem;
             } else {
                 color = colorUser;
@@ -116,11 +111,11 @@ public final class ItemUtils {
 
     public static void pickItemAppType(AppInfoX app, AppCompatImageView icon) {
         ColorStateList color;
-        if (app.getAppInfo().isSpecial()) {
+        if (app.isSpecial()) {
             color = ColorStateList.valueOf(colorSpecial);
             icon.setVisibility(View.VISIBLE);
             icon.setImageResource(R.drawable.ic_round_special_24);
-        } else if (app.getAppInfo().isSystem()) {
+        } else if (app.isSystem()) {
             color = ColorStateList.valueOf(colorSystem);
             icon.setVisibility(View.VISIBLE);
             icon.setImageResource(R.drawable.ic_outline_system_24);
@@ -129,7 +124,7 @@ public final class ItemUtils {
             icon.setVisibility(View.VISIBLE);
             icon.setImageResource(R.drawable.ic_outline_user_24);
         }
-        if ( ! app.getAppInfo().isSpecial() ) {
+        if ( ! app.isSpecial() ) {
             if (app.isDisabled()) {
                 color = ColorStateList.valueOf(colorDisabled);
             }


### PR DESCRIPTION
for me the main purpose for AppInfoX is the abstraction of an entry in the list of "apps".

From my experience it should abstract the usage from outside.
From outside there should not be indirections like via getAppInfo() to determine basic attributes.

The field metainfo is an implementation detail and only exists, because it groups data for parceling.

The user of AppInfoX should not know internal details (from his POV), e.g. if the label is stored in metainfo and the name is not or even why there are two fields for the package name (in AppInfoX and metainfo) should not be visible.

The decisions like isDisabled or isSystem should be implemented at the same level, and in the object that is responsible.
As I understand it, metainfo is only a kind of a data structure for parceling or may be it should be.

This is a first step only, there is obviously more room for improvements, e.g. getPackageInfo etc.

Btw. I think many names should probably be revisited, because the meanings are now widened/changed...
getAppInfo (getMetaInfo?), metainfo (something with parcel?), getPackageLabel (getLabel), etc.