### PR TITLE
killPackage -> preprocess/postprocessPackage

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/handler/action/BackupAppAction.java
+++ b/app/src/main/java/com/machiav3lli/backup/handler/action/BackupAppAction.java
@@ -75,10 +75,9 @@ public class BackupAppAction extends BaseAppAction {
         }
         BackupBuilder backupBuilder = new BackupBuilder(this.getContext(), app.getAppInfo(), appBackupRootUri);
         StorageFile backupDir = backupBuilder.getBackupPath();
-        if (PrefUtils.isKillBeforeActionEnabled(this.getContext())) {
-            Log.d(BackupAppAction.TAG, "Killing package to avoid file changes during backup");
-            this.killPackage(app.getPackageName());
-        }
+
+        Log.d(BackupAppAction.TAG, "preprocess package (to avoid file inconsistencies during backup etc.)");
+        this.preprocessPackage(app.getPackageName());
         BackupProperties backupProperties;
         try {
             if ((backupMode & BaseAppAction.MODE_APK) == BaseAppAction.MODE_APK) {
@@ -114,6 +113,9 @@ public class BackupAppAction extends BaseAppAction {
                     String.format("%s: %s", e.getClass().getSimpleName(), e.getMessage()),
                     false
             );
+        } finally {
+            Log.d(BackupAppAction.TAG, "postprocess package (to set it back to normal operation)");
+            this.postprocessPackage(app.getPackageName());
         }
         Log.i(BackupAppAction.TAG, String.format("%s: Backup done: %s", app, backupProperties));
         return new ActionResult(app, backupProperties, "", true);

--- a/app/src/main/java/com/machiav3lli/backup/handler/action/BackupSpecialAction.java
+++ b/app/src/main/java/com/machiav3lli/backup/handler/action/BackupSpecialAction.java
@@ -106,8 +106,11 @@ public class BackupSpecialAction extends BackupAppAction {
     }
 
     @Override
-    public void killPackage(String packageName) {
+    public void preprocessPackage(String packageName) {
         // stub
-        // Do not kill system apps
+    }
+    @Override
+    public void postprocessPackage(String packageName) {
+        // stub
     }
 }

--- a/app/src/main/java/com/machiav3lli/backup/handler/action/SystemRestoreAppAction.java
+++ b/app/src/main/java/com/machiav3lli/backup/handler/action/SystemRestoreAppAction.java
@@ -94,8 +94,12 @@ public class SystemRestoreAppAction extends RestoreAppAction {
     }
 
     @Override
-    public void killPackage(String packageName) {
+    public void preprocessPackage(String packageName) {
         // stub
-        // Nothing to kill here
+    }
+
+    @Override
+    public void postprocessPackage(String packageName) {
+        // stub
     }
 }


### PR DESCRIPTION
killing apps is only one possibility.
From my POV we still do not know, which method has the best results.

Several methods need to do something before **and** after processing the package.
So I extended the killPackage to preprocessPackage and postprocessPackage.

(what about the names? could be preProcessPackage, or may be prePackage? there are probably other wordings for bracketing)

To ease experimentation, I added several examples, that can be enabled by setting the if (false) to true, the appropriate closing operation is managed automatically (by adding a flag).
There is also an alternative "am kill" (killing only services of the app) instead of "am force-stop" (killing services and the app itself). Just change the comment.

I currently think both ways to kill are too intrusive and create more problems than they solve...

The currently most appealing method is sigstop/sigcont, because in this case the app process(es) cannot do anything and this will probably prevent writes (and other changes to the file system state, e.g. renames, changing attributes, etc.) while the backup is running. It can even prevent indirectly triggered writes (e.g. the app could use an OS service to write something, e.g. SAF).
Unfortunately this needs at least a good blacklist, because you can easily create dead locks if you stop something you curretnly use (like "External Storage").
A blacklist is easy but explicit. It would be a lot better to have a general rule that automatically adapts to future changes in the OS. An ideal method would probably detect a possible dead lock (e.g. not stopping something that is used by OABX) and prevent it.
I didn't think deeper about this, yet.
