### PR TITLE
exclude some packages

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/handler/BackendController.java
+++ b/app/src/main/java/com/machiav3lli/backup/handler/BackendController.java
@@ -31,8 +31,10 @@ public final class BackendController {
     List of packages ignored for any reason
      */
     private static final List<String> ignoredPackages = Arrays.asList(
+            BuildConfig.APPLICATION_ID, // ignore own package, it would send a SIGTERM to itself on backup/restore
             "android", // virtual package. Data directory is /data -> not a good idea to backup
-            BuildConfig.APPLICATION_ID // ignore own package, it would send a SIGTERM to itself on backup/restore
+            "com.google.android.gms",
+            "com.android.externalstorage"
     );
 
     private BackendController() {
@@ -116,5 +118,4 @@ public final class BackendController {
             return null;
         }
     }
-
 }


### PR DESCRIPTION
exclude packages known to have issues / make no sense for a backup.

- com.google.android.gms (Google Play Services)

  takes a lot of time, but the data seems to be completely temporary (yet to be proven)

- com.android.externalstorage (External Storage)

  the service is used by the backup and should never be killed...nor stopped.
  I know, this blacklist is not only meant for killing, but I think External Storage doesn't store relevant data

I'm open for discussion