### PR TITLE
Added: Housekeeping functionality for backup revisions

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/Constants.java
+++ b/app/src/main/java/com/machiav3lli/backup/Constants.java
@@ -64,6 +64,7 @@ public class Constants {
     public static final String PREFS_ENABLESPECIALBACKUPS = "enableSpecialBackups";
     public static final String PREFS_HELP = "help";
     public static final String PREFS_KILLBEFOREACTION = "killBeforeAction";
+    public static final String PREFS_NUM_BACKUP_REVISIONS = "numBackupRevisions";
 
     public static final String BUNDLE_THREADID = "threadId";
     public static final String BUNDLE_USERS = "users";

--- a/app/src/main/java/com/machiav3lli/backup/items/AppInfoX.java
+++ b/app/src/main/java/com/machiav3lli/backup/items/AppInfoX.java
@@ -165,7 +165,7 @@ public class AppInfoX {
                     + backupItem.getBackupProperties().getPackageName()
                     + " but this object is for " + this.getPackageName());
         }
-        Log.d(AppInfoX.TAG, "Deleting " + this);
+        Log.d(AppInfoX.TAG, String.format("[%s] Deleting backup revision %s", this.getPackageName(), backupItem));
         DocumentHelper.deleteRecursive(context, backupItem.getBackupLocation());
         this.backupHistory.remove(backupItem);
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,6 +116,8 @@
     <string name="prefs_quickreboot_summary">Kills the system_server process to force a restart of user space</string>
     <string name="prefs_batchdelete">Delete backups\?</string>
     <string name="prefs_batchdelete_summary">Delete backups of all apps not currently installed.</string>
+    <string name="prefs_numBackupRevisions">Number of backup revisions</string>
+    <string name="prefs_numBackupRevisions_summary">The oldest revision will be deleted upon creation of a new backup if the number is exceeded. Set it to zero to keep all revisions.</string>
     <string name="prefs_logviewer">View the log</string>
     <string name="prefs_unset">Unset</string>
     <string name="prefs_help">Help</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -101,6 +101,15 @@
             android:summary="@string/prefs_deviceprotecteddata_summary"
             android:title="@string/prefs_deviceprotecteddata"
             app:iconSpaceReserved="false" />
+        <androidx.preference.SeekBarPreference
+            android:key="numBackupRevisions"
+            android:summary="@string/prefs_numBackupRevisions_summary"
+            android:title="@string/prefs_numBackupRevisions"
+            android:max="10"
+            android:defaultValue="2"
+            app:showSeekBarValue="true"
+            app:min="0"
+            app:iconSpaceReserved="false" />
         <androidx.preference.CheckBoxPreference
             android:defaultValue="true"
             android:key="copySelfApk"


### PR DESCRIPTION
Small feature, that adds a new option to configure the amount of (valid) backup revisions to keep. The Default value is 2. Cleanup happens _after_ the backup is done. It doesn't matter if the backup was successful or failed. It would just truncate the number of backups to the wanted maximum.