### PR TITLE
use STOP/CONT signals instead of killing the app, killPackage -> preprocess/postprocessPackage

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/handler/action/BackupAppAction.java
+++ b/app/src/main/java/com/machiav3lli/backup/handler/action/BackupAppAction.java
@@ -76,10 +76,13 @@ public class BackupAppAction extends BaseAppAction {
         }
         BackupBuilder backupBuilder = new BackupBuilder(this.getContext(), app.getAppInfo(), appBackupRootUri);
         StorageFile backupDir = backupBuilder.getBackupPath();
-
-        Log.d(BackupAppAction.TAG, "preprocess package (to avoid file inconsistencies during backup etc.)");
-        this.preprocessPackage(app.getPackageName());
+        boolean stopProcess = PrefUtils.isKillBeforeActionEnabled(this.getContext());
         BackupItem backupItem;
+        
+        if (stopProcess) {
+            Log.d(BackupAppAction.TAG, "preprocess package (to avoid file inconsistencies during backup etc.)");
+            this.preprocessPackage(app.getPackageName());
+        }
         try {
             if ((backupMode & BaseAppAction.MODE_APK) == BaseAppAction.MODE_APK) {
                 Log.i(BackupAppAction.TAG, String.format("%s: Backing up package", app));
@@ -116,8 +119,10 @@ public class BackupAppAction extends BaseAppAction {
                     false
             );
         } finally {
-            Log.d(BackupAppAction.TAG, "postprocess package (to set it back to normal operation)");
-            this.postprocessPackage(app.getPackageName());
+            if (stopProcess) {
+                Log.d(BackupAppAction.TAG, "postprocess package (to set it back to normal operation)");
+                this.postprocessPackage(app.getPackageName());
+            }
         }
         Log.i(BackupAppAction.TAG, String.format("%s: Backup done: %s", app, backupItem));
         return new ActionResult(app, backupItem.getBackupProperties(), "", true);

--- a/app/src/main/java/com/machiav3lli/backup/handler/action/BackupAppAction.java
+++ b/app/src/main/java/com/machiav3lli/backup/handler/action/BackupAppAction.java
@@ -76,10 +76,9 @@ public class BackupAppAction extends BaseAppAction {
         }
         BackupBuilder backupBuilder = new BackupBuilder(this.getContext(), app.getAppInfo(), appBackupRootUri);
         StorageFile backupDir = backupBuilder.getBackupPath();
-        if (PrefUtils.isKillBeforeActionEnabled(this.getContext())) {
-            Log.d(BackupAppAction.TAG, "Killing package to avoid file changes during backup");
-            this.killPackage(app.getPackageName());
-        }
+
+        Log.d(BackupAppAction.TAG, "preprocess package (to avoid file inconsistencies during backup etc.)");
+        this.preprocessPackage(app.getPackageName());
         BackupItem backupItem;
         try {
             if ((backupMode & BaseAppAction.MODE_APK) == BaseAppAction.MODE_APK) {
@@ -116,6 +115,9 @@ public class BackupAppAction extends BaseAppAction {
                     String.format("%s: %s", e.getClass().getSimpleName(), e.getMessage()),
                     false
             );
+        } finally {
+            Log.d(BackupAppAction.TAG, "postprocess package (to set it back to normal operation)");
+            this.postprocessPackage(app.getPackageName());
         }
         Log.i(BackupAppAction.TAG, String.format("%s: Backup done: %s", app, backupItem));
         return new ActionResult(app, backupItem.getBackupProperties(), "", true);

--- a/app/src/main/java/com/machiav3lli/backup/handler/action/BackupSpecialAction.java
+++ b/app/src/main/java/com/machiav3lli/backup/handler/action/BackupSpecialAction.java
@@ -106,8 +106,11 @@ public class BackupSpecialAction extends BackupAppAction {
     }
 
     @Override
-    public void killPackage(String packageName) {
+    public void preprocessPackage(String packageName) {
         // stub
-        // Do not kill system apps
+    }
+    @Override
+    public void postprocessPackage(String packageName) {
+        // stub
     }
 }

--- a/app/src/main/java/com/machiav3lli/backup/handler/action/RestoreAppAction.java
+++ b/app/src/main/java/com/machiav3lli/backup/handler/action/RestoreAppAction.java
@@ -66,12 +66,12 @@ public class RestoreAppAction extends BaseAppAction {
 
     public ActionResult run(AppInfoX app, BackupProperties backupProperties, Uri backupLocation, int backupMode) {
         Log.i(RestoreAppAction.TAG, String.format("Restoring up: %s [%s]", app.getPackageName(), app.getPackageLabel()));
+        boolean stopProcess = PrefUtils.isKillBeforeActionEnabled(this.getContext());
+        if (stopProcess) {
+            Log.d(RestoreAppAction.TAG, "preprocess package (to avoid file inconsistencies during backup etc.)");
+            this.preprocessPackage(app.getPackageName());
+        }
         try {
-            boolean stopProcess = PrefUtils.isKillBeforeActionEnabled(this.getContext());
-            if (stopProcess) {
-                Log.d(RestoreAppAction.TAG, "preprocess package (to avoid file inconsistencies during backup etc.)");
-                this.preprocessPackage(app.getPackageName());
-            }
             if ((backupMode & BaseAppAction.MODE_APK) == BaseAppAction.MODE_APK) {
                 this.restorePackage(backupLocation, backupProperties);
                 app.refreshFromPackageManager(this.getContext());

--- a/app/src/main/java/com/machiav3lli/backup/handler/action/RestoreAppAction.java
+++ b/app/src/main/java/com/machiav3lli/backup/handler/action/RestoreAppAction.java
@@ -69,7 +69,7 @@ public class RestoreAppAction extends BaseAppAction {
         try {
             boolean stopProcess = PrefUtils.isKillBeforeActionEnabled(this.getContext());
             if (stopProcess) {
-                Log.d(BackupAppAction.TAG, "preprocess package (to avoid file inconsistencies during backup etc.)");
+                Log.d(RestoreAppAction.TAG, "preprocess package (to avoid file inconsistencies during backup etc.)");
                 this.preprocessPackage(app.getPackageName());
             }
             if ((backupMode & BaseAppAction.MODE_APK) == BaseAppAction.MODE_APK) {
@@ -88,7 +88,7 @@ public class RestoreAppAction extends BaseAppAction {
             );
         } finally {
             if (stopProcess) {
-                Log.d(BackupAppAction.TAG, "postprocess package (to set it back to normal operation)");
+                Log.d(RestoreAppAction.TAG, "postprocess package (to set it back to normal operation)");
                 this.postprocessPackage(app.getPackageName());
             }
         }

--- a/app/src/main/java/com/machiav3lli/backup/handler/action/SystemRestoreAppAction.java
+++ b/app/src/main/java/com/machiav3lli/backup/handler/action/SystemRestoreAppAction.java
@@ -94,8 +94,12 @@ public class SystemRestoreAppAction extends RestoreAppAction {
     }
 
     @Override
-    public void killPackage(String packageName) {
+    public void preprocessPackage(String packageName) {
         // stub
-        // Nothing to kill here
+    }
+
+    @Override
+    public void postprocessPackage(String packageName) {
+        // stub
     }
 }


### PR DESCRIPTION
Killing an app before it's backup runs is a measure to prevent writes to the data directories while saving the data.

But this has several disadvantages:
- it (severely) changes the state of the system (e.g. wallpaper is lost, keyboard back to default, alarm doesn't work, services are no more running)
- you cannot restore the old state, because you don't have the history
- rebooting would be possible to restart all the services and apps that should run all the time, but it still doesn't solve some of the problems (e.g. most visible selection of a default keyboard and changed wallpaper)
- if an app is killed, there might be mechanisms to run it again immediately and this creates even more storage activity

Instead this PR implements pausing the processes belonging to each app by using the low level unix signals STOP and CONT.
The STOP isn't intrusive and doesn't change the state of the system. It's only delaying some things.
The app cannot write to storage or request services from the system while being stopped.

Note, that
- a process can catch the signal and deny it. So these processes continue to run.
- services that the app requested before receiving the signal could still be running.
So it is still possible that writes happen in data directories while the backup is running. Hopefully this is a minimal risk.
- the processes are chosen by the user id of each app (usually each app has it's own user). However there might be write access to the data directories by processes running under system users. Among these may be requests started before the STOP signal arrived.

There are exclusion lists and patterns to prevent stopping processes that are used by the backup process, which would be a dead lock.

This is not the final take, but it should at least be better than killing the apps via "am force-stop".

Note, I didn't remove the "kill-setting", you probably know better what to do.
If you want me to do this, just say a word. I can also find the patch that created it (and the dialog extension with the warning).

Because there is a small risk for a dead lock (if the lists/patterns are not complete), the setting could be reused to disable the STOP feature. In this case it should be used inside the pre/postprocessPackage functions.
If you want this, I can revive some code of the force-stop method I just removed.

I replaced the killPackage function by a bracket of pre- and postprocessPackage to be able to do something before **and** after package processing.