### PR TITLE
StorageFile cache: fix missing clear

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/handler/DocumentContractApi.kt
+++ b/app/src/main/java/com/machiav3lli/backup/handler/DocumentContractApi.kt
@@ -26,17 +26,20 @@ object DocumentContractApi {
         null
     }
 
-    private fun getRawType(context: Context, uri: Uri): String? = try {
-        context.contentResolver.query(uri, null, null, null, null)?.let { cursor ->
-            cursor.run {
-                val mimeTypeMap: MimeTypeMap = MimeTypeMap.getSingleton()
-                if (moveToFirst()) mimeTypeMap.getExtensionFromMimeType(context.contentResolver.getType(uri))
-                else null
-            }.also { cursor.close() }
+    private fun getRawType(context: Context, uri: Uri): String? =
+        try {
+            context.contentResolver.query(uri, null, null, null, null)?.let { cursor ->
+                cursor.run {
+                    val mimeTypeMap: MimeTypeMap = MimeTypeMap.getSingleton()
+                    if (moveToFirst())
+                        mimeTypeMap.getExtensionFromMimeType(context.contentResolver.getType(uri))
+                    else
+                        null
+                }.also { cursor.close() }
+            }
+        } catch (e: Exception) {
+            null
         }
-    } catch (e: Exception) {
-        null
-    }
 
     fun getFlags(context: Context, self: Uri): Long = queryForLong(context, self, DocumentsContract.Document.COLUMN_FLAGS)
 
@@ -53,9 +56,13 @@ object DocumentContractApi {
 
     fun length(context: Context, self: Uri): Long = queryForLong(context, self, DocumentsContract.Document.COLUMN_SIZE)
 
-    fun canRead(context: Context, self: Uri): Boolean = if (context.checkCallingOrSelfUriPermission(self, Intent.FLAG_GRANT_READ_URI_PERMISSION) // Ignore if grant doesn't allow read
-            != PackageManager.PERMISSION_GRANTED) false
-    else !TextUtils.isEmpty(getRawType(context, self)) // Ignore documents without MIME
+    fun canRead(context: Context, self: Uri):
+            Boolean =
+                if (context.checkCallingOrSelfUriPermission(self, Intent.FLAG_GRANT_READ_URI_PERMISSION) // Ignore if grant doesn't allow read
+                                != PackageManager.PERMISSION_GRANTED)
+                    false
+                else
+                    !TextUtils.isEmpty(getRawType(context, self)) // Ignore documents without MIME
 
     fun canWrite(context: Context, self: Uri): Boolean {
         // Ignore if grant doesn't allow write

--- a/app/src/main/java/com/machiav3lli/backup/items/AppInfoX.kt
+++ b/app/src/main/java/com/machiav3lli/backup/items/AppInfoX.kt
@@ -274,21 +274,22 @@ class AppInfoX {
             val backupHistory = ArrayList<BackupItem>()
             try {
                 for (file in appBackupDir.listFiles()) {
-                    // TODO FIX: Randomly failing to read properties files of the updated app on refresh
-                    //  but never on start!! Already. One thing to be noticed is that on some random
-                    //  times those calls run on different threads even though they shouldn't and this
-                    //  never happens on first launch
-                    if (file.isPropertyFile) try {
-                        backupHistory.add(BackupItem(context, file))
-                    } catch (e: BrokenBackupException) {
-                        val message = "Incomplete backup or wrong structure found in ${backupDir.encodedPath}."
-                        Log.w(TAG, message)
-                        logErrors(context, message)
-                    } catch (e: NullPointerException) {
-                        val message = "Incomplete backup or wrong structure found in ${backupDir.encodedPath}."
-                        Log.w(TAG, message)
-                        logErrors(context, message)
-                    }
+                    if (file.isPropertyFile)
+                        try {
+                            backupHistory.add(BackupItem(context, file))
+                        } catch (e: BrokenBackupException) {
+                            val message = "Incomplete backup or wrong structure found in ${backupDir.encodedPath}."
+                            Log.w(TAG, message)
+                            logErrors(context, message)
+                        } catch (e: NullPointerException) {
+                            val message = "(Null) Incomplete backup or wrong structure found in ${backupDir.encodedPath}."
+                            Log.w(TAG, message)
+                            logErrors(context, message)
+                        } catch (e: Exception) {
+                            val message = "(catchall) Incomplete backup or wrong structure found in ${backupDir.encodedPath}."
+                            Log.w(TAG, message)
+                            logErrors(context, message)
+                        }
                 }
             } catch (e: FileNotFoundException) {
                 Log.w(TAG, "Failed getting backup history: $e")

--- a/app/src/main/java/com/machiav3lli/backup/items/StorageFile.kt
+++ b/app/src/main/java/com/machiav3lli/backup/items/StorageFile.kt
@@ -67,6 +67,7 @@ open class StorageFile protected constructor(val parentFile: StorageFile?, priva
         val uriString = this.uri.toString()
         if (cacheDirty) {
             cacheDirty = false
+            cache.clear()
         }
         if (cache[uriString].isNullOrEmpty()) {
             val resolver = context.contentResolver


### PR DESCRIPTION
the cache must be cleared if it is dirty (the cache.clear() in StorageFile)

the other changes are cosmetic, which I changed while trying to understand the code.
Mainly "fighting" Spaghetti code and "wrong" indentation (is this created by Kotlin converter?).
May be discussed.

At least
```
fun ... if ....
  ...
else
  ...
```
is very strange.
I also don't like
```
if ... try {
} catch {
}
```
`fun` does not pair with `else` and `catch` does not pair with `if`...I read these pairs as errors in structure...
I hope we agree on those