### PR TITLE
only get apps list if empty or storage cache is dirty

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/activities/MainActivityX.kt
+++ b/app/src/main/java/com/machiav3lli/backup/activities/MainActivityX.kt
@@ -488,7 +488,8 @@ class MainActivityX : BaseActivity(), BatchConfirmDialog.ConfirmListener {
         sheetSortFilter = SortFilterSheet(getFilterPreferences(this))
         Thread {
             try {
-                appsList = getApplicationList(this.applicationContext)
+                if (appsList.isNullOrEmpty() || StorageFile.cacheDirty)
+                    appsList = getApplicationList(this.applicationContext)
                 getPrivateSharedPrefs(this).getBoolean(Constants.PREFS_ENABLESPECIALBACKUPS, false)
                 val filteredList = applyFilter(appsList!!,
                         getFilterPreferences(this).toString(), this)


### PR DESCRIPTION
A simple solution to something I wanted to change for some time.

The app list is only reread from "disk" if "something" changes, which we already try to maintain in cacheDirty.
I think this should be the same logic, so lets use the same flag.

May be there are better ways, but this was so simple, that I couldn't resist.

So far it seems to work (try my latest apk on Telegram)

There is one weird effect.
If I set the filter to "Apps without backup" I get a list with apps "without backups".
No pun intended!
This means, after a full backup, this list should be empty, but it is full and each app is missing the backups.
I know, the empty list is switched to the full list, but there must be something wrong with it.
Will have a look...