### PR TITLE
fix restore: openArchiveFile, uncompressTo

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/utils/TarUtils.kt
+++ b/app/src/main/java/com/machiav3lli/backup/utils/TarUtils.kt
@@ -144,8 +144,9 @@ object TarUtils {
 
     @Throws(IOException::class)
     fun uncompressTo(archive: TarArchiveInputStream, targetDir: File?) {
-        var tarEntry: TarArchiveEntry
+        var tarEntry: TarArchiveEntry? = null
         while (archive.nextTarEntry.also { tarEntry = it } != null) {
+            val tarEntry = tarEntry!!
             val targetPath = File(targetDir, tarEntry.name)
             Log.d(TAG, String.format("Uncompressing %s (filesize: %d)", tarEntry.name, tarEntry.realSize))
             var doChmod = true

--- a/app/src/main/java/com/machiav3lli/backup/utils/TarUtils.kt
+++ b/app/src/main/java/com/machiav3lli/backup/utils/TarUtils.kt
@@ -123,8 +123,7 @@ object TarUtils {
 
     @Throws(IOException::class, ShellCommandFailedException::class)
     fun suUncompressTo(archive: TarArchiveInputStream, targetDir: String?) {
-        var tarEntry: TarArchiveEntry
-        while (archive.nextTarEntry.also { tarEntry = it } != null) {
+        generateSequence {archive.nextTarEntry} .forEach { tarEntry ->
             val file = File(targetDir, tarEntry.name)
             Log.d(TAG, "Extracting ${tarEntry.name}")
             if (tarEntry.isDirectory) {
@@ -144,9 +143,7 @@ object TarUtils {
 
     @Throws(IOException::class)
     fun uncompressTo(archive: TarArchiveInputStream, targetDir: File?) {
-        var tarEntry: TarArchiveEntry? = null
-        while (archive.nextTarEntry.also { tarEntry = it } != null) {
-            val tarEntry = tarEntry!!
+        generateSequence {archive.nextTarEntry} .forEach { tarEntry ->
             val targetPath = File(targetDir, tarEntry.name)
             Log.d(TAG, String.format("Uncompressing %s (filesize: %d)", tarEntry.name, tarEntry.realSize))
             var doChmod = true


### PR DESCRIPTION
* don't use the **use** clause here, because it closes the inner stream
* the other one is tricky:

```
        var tarEntry: TarArchiveEntry
        while (archive.nextTarEntry.also { tarEntry = it } != null) {
```

the compiler is clever and detects that `tarEntry` is always initialized. But it is dumb, because it doesn't detect that `archive.nextTarEntry` (Java) can be `null` (at the end, though it's not explicitly Nullable). In this case it throws an exception.

This is my first try to solve that without changing too much:

```
        var tarEntry: TarArchiveEntry? = null
        while (archive.nextTarEntry.also { tarEntry = it } != null) {
            val tarEntry = tarEntry!!
```
The tarEntry is now Nullable, but because there are many occurances in the loop it's assigned to the same name again, while checking if it's `null`.
* this could be another name (to avoid a warning, using refactor)
* a better way would be a while like loop that provides an argument to the loop block, or wrapping the nextTarEntry in an iterator, generator or similar