### PR TITLE
Fix #187

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/handler/action/BaseAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/handler/action/BaseAppAction.kt
@@ -29,6 +29,8 @@ import com.topjohnwu.superuser.Shell
 
 abstract class BaseAppAction protected constructor(protected val context: Context, protected val shell: ShellHandler) {
 
+    protected val deviceProtectedStorageContext: Context = context.createDeviceProtectedStorageContext()
+
     fun getBackupArchiveFilename(what: String, isEncrypted: Boolean): String {
         return "$what.tar.gz${if (isEncrypted) ".enc" else ""}"
     }

--- a/app/src/main/java/com/machiav3lli/backup/handler/action/RestoreAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/handler/action/RestoreAppAction.kt
@@ -401,7 +401,7 @@ open class RestoreAppAction(context: Context, shell: ShellHandler) : BaseAppActi
         Log.d(TAG, String.format(LOG_EXTRACTING_S, backupProperties.packageName, backupFilename))
         val backupArchive = backupLocation.findFile(backupFilename)
                 ?: throw RestoreFailedException(String.format(LOG_BACKUP_ARCHIVE_MISSING, backupFilename))
-        genericRestoreFromArchive(backupArchive.uri, app.deviceProtectedDataDir, backupProperties.isEncrypted, context.cacheDir)
+        genericRestoreFromArchive(backupArchive.uri, app.deviceProtectedDataDir, backupProperties.isEncrypted, deviceProtectedStorageContext.cacheDir)
         genericRestorePermissions(
                 BACKUP_DIR_DEVICE_PROTECTED_FILES,
                 File(app.deviceProtectedDataDir)


### PR DESCRIPTION
Fixes restoring apps on Lineage 17.1. I do not know why copying from the cachedir `/data/user/0/com.machiav3lli.backup.debug/cache/` to another directory gives the `Operation not permitted` error, but using `/storage/emulated/0/Android/data/com.machiav3lli.backup.debug/cache` seems to work.