### PR TITLE
add mtime to backups (restore still WIP)

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/utils/DocumentUtils.kt
+++ b/app/src/main/java/com/machiav3lli/backup/utils/DocumentUtils.kt
@@ -68,7 +68,7 @@ object DocumentUtils {
     fun suRecursiveCopyFileToDocument(context: Context, filesToBackup: List<ShellHandler.FileInfo>, targetUri: Uri) {
         val resolver = context.contentResolver
         for (file in filesToBackup) {
-            val parentUri = targetUri.buildUpon().appendEncodedPath(File(file.filepath).parent).build()
+            val parentUri = targetUri.buildUpon().appendEncodedPath(File(file.filePath).parent).build()
             val parentFile = StorageFile.fromUri(context, parentUri)
             when (file.fileType) {
                 FileType.REGULAR_FILE -> suCopyFileToDocument(resolver, file, StorageFile.fromUri(context, parentUri))

--- a/app/src/main/java/com/machiav3lli/backup/utils/FileUtils.kt
+++ b/app/src/main/java/com/machiav3lli/backup/utils/FileUtils.kt
@@ -95,7 +95,7 @@ object FileUtils {
         return path.substring(path.lastIndexOf(File.separator) + 1)
     }
 
-    fun translatePosixPermissionToMode(permissions: String): Short {
+    fun translatePosixPermissionToMode(permissions: String): Int {
         var str = permissions.takeLast(9)
         str = str.replace('s', 'x', false)
         str = str.replace('S', '-', false)
@@ -103,13 +103,13 @@ object FileUtils {
         return translatePosixPermissionToMode(set)
     }
 
-    fun translatePosixPermissionToMode(permissions: Set<PosixFilePermission?>): Short {
+    fun translatePosixPermissionToMode(permissions: Set<PosixFilePermission?>): Int {
         var mode = 0
         for (action in PosixFilePermission.values()) {
             mode = mode shl 1
             mode += if (permissions.contains(action)) 1 else 0
         }
-        return mode.toShort()
+        return mode
     }
 
     class BackupLocationIsAccessibleException : Exception {

--- a/app/src/main/java/com/machiav3lli/backup/utils/TarUtils.kt
+++ b/app/src/main/java/com/machiav3lli/backup/utils/TarUtils.kt
@@ -182,5 +182,10 @@ fun uncompressTo(archive: TarArchiveInputStream, targetDir: File?) {
                 throw IOException("Unable to chmod $targetPath to ${tarEntry.mode}: $e")
             }
         }
+        try {
+            targetPath.setLastModified(tarEntry.modTime.time)
+        } catch (e: ErrnoException) {
+            throw IOException("Unable to set modification time on $targetPath to ${tarEntry.modTime}: $e")
+        }
     }
 }

--- a/app/src/main/java/com/machiav3lli/backup/utils/TarUtils.kt
+++ b/app/src/main/java/com/machiav3lli/backup/utils/TarUtils.kt
@@ -75,14 +75,15 @@ fun addFilepath(archive: TarArchiveOutputStream, inputFilepath: File, parent: St
 @Throws(IOException::class)
 fun suAddFiles(archive: TarArchiveOutputStream, allFiles: List<ShellHandler.FileInfo>) {
     for (file in allFiles) {
-        Log.d(TAG, String.format("Adding %s to archive (filesize: %d)", file.filepath, file.fileSize))
+        Log.d(TAG, String.format("Adding %s to archive (filesize: %d)", file.filePath, file.fileSize))
         var entry: TarArchiveEntry
         when (file.fileType) {
             FileType.REGULAR_FILE -> {
-                entry = TarArchiveEntry(file.filepath)
+                entry = TarArchiveEntry(file.filePath)
                 entry.size = file.fileSize
                 entry.setNames(file.owner, file.group)
                 entry.mode = FILE_MODE_OR_MASK or file.fileMode.toInt()
+                entry.modTime = file.fileModTime
                 archive.putArchiveEntry(entry)
                 try {
                     ShellHandler.quirkLibsuReadFileWorkaround(file, archive)
@@ -93,14 +94,14 @@ fun suAddFiles(archive: TarArchiveOutputStream, allFiles: List<ShellHandler.File
             FileType.BLOCK_DEVICE -> throw NotImplementedError("Block devices should not occur")
             FileType.CHAR_DEVICE -> throw NotImplementedError("Char devices should not occur")
             FileType.DIRECTORY -> {
-                entry = TarArchiveEntry(file.filepath, TarConstants.LF_DIR)
+                entry = TarArchiveEntry(file.filePath, TarConstants.LF_DIR)
                 entry.setNames(file.owner, file.group)
                 entry.mode = DIR_MODE_OR_MASK or file.fileMode.toInt()
                 archive.putArchiveEntry(entry)
                 archive.closeArchiveEntry()
             }
             FileType.SYMBOLIC_LINK -> {
-                entry = TarArchiveEntry(file.filepath, TarConstants.LF_LINK)
+                entry = TarArchiveEntry(file.filePath, TarConstants.LF_LINK)
                 entry.linkName = file.linkName
                 entry.setNames(file.owner, file.group)
                 entry.mode = FILE_MODE_OR_MASK or file.fileMode.toInt()
@@ -108,7 +109,7 @@ fun suAddFiles(archive: TarArchiveOutputStream, allFiles: List<ShellHandler.File
                 archive.closeArchiveEntry()
             }
             FileType.NAMED_PIPE -> {
-                entry = TarArchiveEntry(file.filepath, TarConstants.LF_FIFO)
+                entry = TarArchiveEntry(file.filePath, TarConstants.LF_FIFO)
                 entry.setNames(file.owner, file.group)
                 entry.mode = FILE_MODE_OR_MASK or file.fileMode.toInt()
                 archive.putArchiveEntry(entry)


### PR DESCRIPTION
mtime **IS** important for some purposes. Though I didn't see any effect up to now (but I don't restore!), I am quite sure that mtimes are used by usual software. It only might be a special Android thingy to ignore it, but for backups I would try to stay on the safe side.

if that matters, TiB and Swift restore the mtimes...

I push this early, before I have even started the restore part, because users are already creating backups with wrong mtimes.