### PR TITLE
fix: missing backups on nextcloud (and similar)

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/handler/DocumentContractApi.kt
+++ b/app/src/main/java/com/machiav3lli/backup/handler/DocumentContractApi.kt
@@ -53,7 +53,6 @@ object DocumentContractApi {
     fun isPropertyFile(context: Context, self: Uri): Boolean {
         val type = getRawType(context, self)
         return !(DocumentsContract.Document.MIME_TYPE_DIR == type || TextUtils.isEmpty(type))
-                && self.toString().endsWith(".properties")
     }
 
     fun lastModified(context: Context, self: Uri): Long = queryForLong(context, self, DocumentsContract.Document.COLUMN_LAST_MODIFIED)


### PR DESCRIPTION
I once changed isPropertyFile to test the uri(!) for ".properties", which is wrong (but worked for local storage).
The uris for nextcloud (and probably others) only contain meaningless numbers.