### PR TITLE
Apply correct SELinux context after data restore

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
@@ -342,7 +342,9 @@ open class RestoreAppAction(context: Context, shell: ShellHandler) : BaseAppActi
                 return
             }
             Timber.d("Changing owner and group of '$targetDir' to ${uidgid[0]}:${uidgid[1]} and restoring selinux context")
-            val command = prependUtilbox("chown -R ${uidgid[0]}:${uidgid[1]} ${java.lang.String.join(" ", *chownTargets)} && restorecon -R -v \"$targetDir\"")
+            val defaultContext = "u:object_r:app_data_file:s0:c512,c768"
+            val command = prependUtilbox("chown -R ${uidgid[0]}:${uidgid[1]} ${java.lang.String.join(" ", *chownTargets)} " +
+                    "&& chcon -R -v $defaultContext \"$targetDir\"")
             runAsRoot(command)
         } catch (e: ShellCommandFailedException) {
             val errorMessage = "Could not update permissions for $type"


### PR DESCRIPTION
Fixes #213.
TL;DR: It reads the SELinux context from the directory and applies it recursively to the app data.

First I have looked into how Android implements SELinux. Besides the normal users, roles and types it uses Multi-Category Security (MCS). So an app data context might be `u:object_r:app_data_file:s0:c87,c257,c512,c768 `. 
The `u:object_r:app_data_file` is always the same and already correct, so we can ignore that. `s0` is also constant (sensitivity level 0) and correct. 

The problem after a data restore lies in the categories. It usually has 4 categories (range c0 - c1023) in 2 pairs. `c512,c768` is always there for apps, but the other pair changes:

> Android devices use dynamically generated MCS categories so that an app running on behalf of one user cannot read or write files created by the same app running on behalf of another user (see the Security Enhancements for Android - Computing a Process Context section). 

Source: https://selinuxproject.org/page/NB_MAC

An processes must belong to all categories to be able to access the corresponding file. 
This happens after a data restore currently:
```
raphael:/data/user/0/org.tasks # ls -laZ                                                                                                                                                                                                                                             
drwx------  11 u0_a435 u0_a435       u:object_r:app_data_file:s0:c171,c257,c512,c768   4096 2021-01-19 14:52 .
```
So `restorecon` sets the dynamic pair to `c171,c257` and this causes the target app to crash, because it can't read its databases... Apparently it inherits the context/categories from the OABX process:
```
raphael:/data/app # ps -AZ | grep com.machiav3lli.backup                                                                                                                                                                                                                             
u:r:untrusted_app_29:s0:c171,c257,c512,c768 u0_a427 2106 740 14313984 166088 SyS_epoll_wait  0 S com.machiav3lli.backup.debug
```
Correct would be `c179,c257` instead:
```
raphael:/data/user/0/org.tasks # ps -AZ | grep org.tasks                                                                                                                                                                                                                             
u:r:untrusted_app:s0:c179,c257,c512,c768 u0_a435 7073 740 14269616 165588 SyS_epoll_wait     0 S org.tasks
```

Here is a explanation how Android dynamically generates these categories:
https://selinuxproject.org/page/NB_SEforAndroid_2#Computing_a_Context
I have to admit that I don't quite understand how they get all parameters and calculate the result, looks like a native system library that does this internally? Maybe someone knows more in that regard.

This PR uses a easier solution: it reads the correct context from the directory and applies it with `chcon`, just like already done with UID:GID.