### PR TITLE
fix: missing files in special.* breaking the rest of the package

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/actions/BackupSpecialAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/BackupSpecialAction.kt
@@ -65,9 +65,11 @@ class BackupSpecialAction(context: Context, shell: ShellHandler) : BackupAppActi
                 try {
                     fileInfos = shell.suGetDetailedDirectoryContents(filePath.removeSuffix("/"), isDirSource, parent)
                 } catch(e: ShellCommandFailedException) {
-                    if(e.shellResult.err.toString().contains("No such file or directory", ignoreCase = true))
-                        continue
-                    throw(e)
+                    continue  //TODO hg42: avoid checking the error message text for now
+                    //TODO hg42: alternative implementation, better replaced this by API, when root permissions available, e.g. via Shizuku
+                    //    if(e.shellResult.err.toString().contains("No such file or directory", ignoreCase = true))
+                    //        continue
+                    //    throw(e)
                 }
                 if (isDirSource) {
                     // also add directory

--- a/app/src/main/java/com/machiav3lli/backup/actions/BackupSpecialAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/BackupSpecialAction.kt
@@ -61,7 +61,14 @@ class BackupSpecialAction(context: Context, shell: ShellHandler) : BackupAppActi
                 val file = File(filePath!!)
                 val isDirSource = filePath.endsWith("/")
                 val parent = if (isDirSource) file.name else null
-                val fileInfos = shell.suGetDetailedDirectoryContents(filePath.removeSuffix("/"), isDirSource, parent)
+                var fileInfos : List<ShellHandler.FileInfo>;
+                try {
+                    fileInfos = shell.suGetDetailedDirectoryContents(filePath.removeSuffix("/"), isDirSource, parent)
+                } catch(e: ShellCommandFailedException) {
+                    if(e.shellResult.err.toString().contains("No such file or directory", ignoreCase = true))
+                        continue
+                    throw(e)
+                }
                 if (isDirSource) {
                     // also add directory
                     filesToBackup.add(


### PR DESCRIPTION
e.g. special.wallpaper
```
                                "$userDir/wallpaper",
                                "$userDir/wallpaper_info.xml"
```
if $userDir/wallpaper does not exist, the other file isn't backed up.

EDIT: removed:

> I'm not happy with checking the error message. This may be dependend on the language and the message may change in the future.
> However it needs root, so we cannot check via an API (unless we can use root permissions for APIs, e.g. via Shizuku).
> It's not very likely to get other exceptions from suGetDetailedDirectoryContents, so we might remove the check.

DONE: removed the check
