### PR TITLE
fix: don't throw exceptions on some special files to be backed up (socket...)

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/utils/DocumentUtils.kt
+++ b/app/src/main/java/com/machiav3lli/backup/utils/DocumentUtils.kt
@@ -63,12 +63,16 @@ object DocumentUtils {
     fun suRecursiveCopyFileToDocument(context: Context, filesToBackup: List<ShellHandler.FileInfo>, targetUri: Uri) {
         val resolver = context.contentResolver
         for (file in filesToBackup) {
-            val parentUri = targetUri.buildUpon().appendEncodedPath(File(file.filePath).parent).build()
-            val parentFile = StorageFile.fromUri(context, parentUri)
-            when (file.fileType) {
-                FileType.REGULAR_FILE -> suCopyFileToDocument(resolver, file, StorageFile.fromUri(context, parentUri))
-                FileType.DIRECTORY -> parentFile.createDirectory(file.filename)
-                else -> Timber.e("SAF does not support ${file.fileType}")
+            try {
+                val parentUri = targetUri.buildUpon().appendEncodedPath(File(file.filePath).parent).build()
+                val parentFile = StorageFile.fromUri(context, parentUri)
+                when (file.fileType) {
+                    FileType.REGULAR_FILE -> suCopyFileToDocument(resolver, file, StorageFile.fromUri(context, parentUri))
+                    FileType.DIRECTORY -> parentFile.createDirectory(file.filename)
+                    else -> Timber.e("SAF does not support ${file.fileType} for ${file.filePath}")
+                }
+            } catch(e: Throwable) {
+                LogUtils.logException(e)
             }
         }
     }


### PR DESCRIPTION
don't throw exceptions on these special files, because they stop the loop
* sockets need not to be backed up, they are automatically created and removed -> ignore
* char and block devices should not occur (says the former comment),
  I think, they could eventually be backed up and restored, but this seems to be unnecessary -> later?

if those devices occur, we should eventually add an error to the action, but it's unclear how to propagate them to the ui level