### PR TITLE
fix selinux context via restorecon in case the context is reported as "?"

### DIFF
--- a/app/src/androidTest/java/SELinuxTest.kt
+++ b/app/src/androidTest/java/SELinuxTest.kt
@@ -1,0 +1,51 @@
+
+import com.machiav3lli.backup.handler.ShellHandler
+import org.junit.Assert
+import org.junit.Test
+import timber.log.Timber
+
+class SELinuxTest {
+
+    @Test
+    fun test_ls_dZ() {
+        val command = "toybox ls -dZ /"
+        val shellResult = ShellHandler.runAsRoot(command)
+        val context = shellResult.out[0].split(" ", limit = 2)[0]
+        Timber.i("$command -> '${shellResult.out[0]}' => context = '$context'")
+
+        Assert.assertNotNull(context)
+        Assert.assertNotEquals("?", context)
+    }
+
+    @Test
+    fun test_ls_dlZ() {
+        val command = "toybox ls -dlZ /"
+        val shellResult = ShellHandler.runAsRoot(command)
+        val context = shellResult.out[0].split(" ", limit = 6)[4]
+        Timber.i("$command -> '${shellResult.out[0]}' => context = '$context'")
+
+        Assert.assertNotNull(context)
+        Assert.assertNotEquals("?", context)
+    }
+
+    @Test
+    fun test_stat_C() {
+        val command = "toybox stat -c '%U %G %C' /"
+        val shellResult = ShellHandler.runAsRoot(command)
+        val context = shellResult.out[0].split(" ", limit = 3)[2]
+        Timber.i("$command -> '${shellResult.out[0]}' => context = '$context'")
+
+        Assert.assertNotNull(context)
+        Assert.assertNotEquals("?", context)
+    }
+
+    @Test
+    fun test_suGetOwnerGroupContext() {
+        val userGroupContext = ShellHandler().suGetOwnerGroupContext("/")
+        val context = userGroupContext[2]
+        Timber.i("suGetOwnerGroupContext -> ${userGroupContext.joinToString("', '", "'", "'")} => context = '$context'")
+
+        Assert.assertNotNull(context)
+        Assert.assertNotEquals("?", context)
+    }
+}

--- a/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
@@ -353,7 +353,9 @@ open class RestoreAppAction(context: Context, shell: ShellHandler) : BaseAppActi
                     "$utilBoxQuoted chown -R ${uidgidcon[0]}:${uidgidcon[1]} ${
                         quoteMultiple(chownTargets)
                     }"
-            if(uidgidcon[2] != "?")  //TODO hg: if context is "?", what does it mean?
+            if(uidgidcon[2] == "?") //TODO hg42: when does it happen?
+                command += " ; restorecon -RF -v ${quote(targetDir)}"
+            else
                 command += " ; chcon -R -v '${uidgidcon[2]}' ${quote(targetDir)}"
             runAsRoot(command)
         } catch (e: ShellCommandFailedException) {

--- a/app/src/main/java/com/machiav3lli/backup/handler/ShellHandler.kt
+++ b/app/src/main/java/com/machiav3lli/backup/handler/ShellHandler.kt
@@ -32,9 +32,9 @@ import java.text.SimpleDateFormat
 import java.util.*
 import java.util.regex.Pattern
 
-val UTILBOX_NAMES = listOf("toybox", "busybox")
-
 class ShellHandler {
+
+    val UTILBOX_NAMES = listOf("toybox", "busybox")
 
     @Throws(ShellCommandFailedException::class)
     fun suGetDirectoryContents(path: File): Array<String> {
@@ -80,9 +80,11 @@ class ShellHandler {
      */
     @Throws(ShellCommandFailedException::class, UnexpectedCommandResult::class)
     fun suGetOwnerGroupContext(filepath: String): Array<String> {
-        val command = "$utilBoxQuoted stat -c '%u %g %C' ${quote(filepath)}"
+        //val command = "$utilBoxQuoted stat -c '%u %g %C' ${quote(filepath)}"
+        val command = "$utilBoxQuoted ls -dnZ ${quote(filepath)}"
         val shellResult = runAsRoot(command)
-        val result = shellResult.out[0].split(" ").toTypedArray()
+        //val result = shellResult.out[0].split(" ").toTypedArray()
+        val result = shellResult.out[0].split(" ",limit=6).slice(2..4).toTypedArray()
         if (result.size != 3) {
             throw UnexpectedCommandResult("'$command' should have returned 3 values, but produced ${result.size}", shellResult)
         }


### PR DESCRIPTION
this fixes reports, that the selinux contexts are not restored.
The selinux patch from Jakeler doesn't seem to work in all cases.

There are cases where stat returns a context of "?".
Actually, there seem to be more systems where restorecon gives the correct result, while on the other hand stat doesn't work.
EDIT: it's the result for an unknown format character: "%C"

In this case we don't know the context of the directory and thus cannot set the context of the including files.
Before this patch, the context would not be set.
The patch adds a fall back to the former solution using restorecon, which usually also copies the context from the directory to it's contents (but for Jakeler this didn't seem to work).
I also added -F (force) to restorecon, in case it matters.

PS: we could eventually use a flag, to avoid the stat, once we know the stat only gives the "?". But I currently don't know, if it happens for all files or only in some cases.
I need to investigate the toybox sources for that.