### PR TITLE
more shell tests

### DIFF
--- a/app/src/androidTest/java/optional/ShellOptionalTests.kt
+++ b/app/src/androidTest/java/optional/ShellOptionalTests.kt
@@ -1,9 +1,14 @@
 package optional
+import com.machiav3lli.backup.handler.ShellHandler
+import com.machiav3lli.backup.handler.ShellHandler.Companion.runAsRoot
 import org.jetbrains.annotations.TestOnly
 import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.TestFactory
 import tests.ShellTests
 import tests.ShellTests.Companion.safeCommandLength
 import timber.log.Timber
@@ -93,4 +98,63 @@ class ShellOptionalTests {
                 results.values.all { it >= safeCommandLength }
         )
     }
+
+    @Test
+    fun test_escapes() {    // this shows that backslash expansion is not done on shell level
+        assertEquals(       // mksh echo (expansion of escape codes)
+            " 07 08 0c 0a 0d 09 0b 1b 1b e1 88 b4 ef bf bd",
+            runAsRoot(
+                """echo -n "\a\b\f\n\r\t\v\e\E\u1234\U123456" | toybox od -t x1 -A none"""
+            ).out.joinToString("")
+        )
+        assertEquals(       // toybox echo (no expansion)
+            " 5c 61 5c 62 5c 66 5c 6e 5c 72 5c 74 5c 76 5c 65 5c 45 5c 75 31 32 33 34 5c 55 31 32 33 34 35 36",
+            runAsRoot(
+                """toybox echo -n "\a\b\f\n\r\t\v\e\E\u1234\U123456" | toybox od -t x1 -A none"""
+            ).out.joinToString("")
+        )
+    }
+
+    val ext = ".nonExistingExt_${Thread.currentThread().id}"
+    val dir = "/data/local/tmp"
+    //val dir = "/cache"
+
+    @TestFactory
+    @ExperimentalStdlibApi
+    fun test_quote() =
+            (
+                 ((0..32) + (128..160)).map { it.toChar() }
+                     //.filter { c -> ! (c.toInt() == 0 || c.toInt() == 173 || (c.toInt().and(127)).toChar() in "\t\n\r ") }
+                     .map { it.toString() + ext }
+            ).map { filename ->
+            DynamicTest.dynamicTest(
+                "char ${filename[0].toInt()} : file '$filename'"
+            ) {
+                try {
+                    runAsRoot("toybox rm $dir/*$ext")
+                } catch (e: Throwable) {
+                }
+
+                assertEquals(
+                    0,
+                    runAsRoot("toybox touch ${ShellHandler.quote("$dir/$filename")}")
+                        .code
+                )
+                assertEquals(
+                    "$dir/$filename",
+                    runAsRoot("toybox echo $dir/*$ext")
+                        .out.joinToString(";")
+                )
+                assertEquals(
+                    "$dir/$filename",
+                    runAsRoot("toybox ls -dlZ $dir/*$ext")
+                        .out.joinToString(";").split(" ", limit = 9)[8]
+                )
+                assertEquals(
+                    0,
+                    runAsRoot("toybox rm ${ShellHandler.quote("$dir/$filename")}")
+                        .code
+                )
+            }
+        }
 }

--- a/app/src/androidTest/java/tests/ShellTests.kt
+++ b/app/src/androidTest/java/tests/ShellTests.kt
@@ -3,18 +3,19 @@ import com.machiav3lli.backup.handler.ShellHandler
 import com.machiav3lli.backup.utils.LogUtils
 import com.machiav3lli.backup.utils.iterableToString
 import com.topjohnwu.superuser.Shell
-import junit.framework.Assert.assertEquals
 import org.jetbrains.annotations.TestOnly
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.DynamicTest.dynamicTest
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestFactory
 
 @DisplayName("shell commands")
 class ShellTests {
 
     companion object {
 
-        val safeCommandLength = 130_000
+        const val safeCommandLength = 130_000
 
         @TestOnly
         fun checkCommandLength(commandStub: String, length: Int, check: String = "api"): Boolean {
@@ -40,7 +41,7 @@ class ShellTests {
     }
 
     @Test
-    @DisplayName("safe command length works")
+    @DisplayName("safe command length ($safeCommandLength)")
     fun test_safeCommandLength() {          // test a line length everyone should be able to process
         assertTrue(
                 checkCommandLength("toybox echo -n", safeCommandLength)
@@ -50,30 +51,53 @@ class ShellTests {
         )
     }
 
-    @Test
-    @DisplayName("quote()")
-    fun test_quote() {
-        val ext = ".aNoNeXiStEnTExt"
-        val filename = """test    file    \|$&"'`[](){}=:;?<~>-+!%^#*,""" + ext
-        val dir = "/data/local/tmp"
-        //val dir = "/cache"
-        try { ShellHandler.runAsRoot("toybox rm $dir/*$ext") } catch(e: Throwable) {}
-        assertEquals(
-            0,
-            ShellHandler.runAsRoot("toybox touch ${ShellHandler.quote("$dir/$filename")}").code
-        )
-        assertEquals(
-            "$dir/$filename",
-            ShellHandler.runAsRoot("toybox echo $dir/*$ext").out.joinToString(";")
-        )
-        assertEquals(
-            "$dir/$filename",
-            ShellHandler.runAsRoot("toybox ls -dlZ $dir/*$ext").out.joinToString(";").split(" ", limit=9)[8]
-        )
-        assertEquals(
-            0,
-            ShellHandler.runAsRoot("toybox rm ${ShellHandler.quote("$dir/$filename")}").code
-        )
-    }
+    val ext = ".nonExistingExt_${Thread.currentThread().id}"
+    val dir = "/data/local/tmp"
+    //val dir = "/cache"
+
+    @TestFactory
+    @DisplayName("quote")
+    @ExperimentalStdlibApi
+    fun test_quote() =
+        listOf(
+            """test   ,\|$&"'`[](){}=:;?<~>-+!%^#*""" + ext,
+            """test   \a\b\f\n\r\t\v\e\E\u1234\U123456""" + ext,
+            (0..32).map { it.toChar() }.filter { c -> !(c.toInt() == 0 || c in "\n\r") }
+                .joinToString("") + ext,
+            (33..127).map { it.toChar() }.filter { c -> !(c.isLetterOrDigit() || c == '/') }
+                .joinToString("") + ext,
+            // fails: (0..32).map { (128+it).toChar() }.filter { c -> ! (c.toInt() == 0 || c.toInt() == 173 || (c.toInt().and(127)).toChar() in "\t\n\r ") }.joinToString("") + ext,
+            (33..127).map { (128 + it).toChar() }.joinToString("") + ext
+        ).map { filename ->
+            dynamicTest(
+                "file '$filename' (${filename[0].toInt()})"
+            ) {
+                try {
+                    runAsRoot("toybox rm $dir/*$ext")
+                } catch (e: Throwable) {
+                }
+
+                assertEquals(
+                    0,
+                    runAsRoot("toybox touch ${quote("$dir/$filename")}")
+                        .code
+                )
+                assertEquals(
+                    "$dir/$filename",
+                    runAsRoot("toybox echo $dir/*$ext")
+                        .out.joinToString(";")
+                )
+                assertEquals(
+                    "$dir/$filename",
+                    runAsRoot("toybox ls -dlZ $dir/*$ext")
+                        .out.joinToString(";").split(" ", limit = 9)[8]
+                )
+                assertEquals(
+                    0,
+                    runAsRoot("toybox rm ${quote("$dir/$filename")}")
+                        .code
+                )
+            }
+        }
 }
 


### PR DESCRIPTION
the purpose is mainly testing every character value by building file names from ranges of character values.
The quoting works so far.

One thing remains open for discussion:
character values from 128 to 160 (space + 128) all fail, they seem to be removed from the file name in some way.
I had no time to debug this.

I think, the part from 128 to 160 can be added at the time we find the solution for this.