### PR TITLE
fix conditional executions

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
@@ -207,7 +207,7 @@ open class RestoreAppAction(context: Context, shell: ShellHandler) : BaseAppActi
             Timber.w("Weird configuration. Expecting that the system does not allow installing from OABX's own data directory. Copying the apk to $stagingApkPath")
         }
         var success = false
-        success = try {
+        try {
             // Try it with a staging path. This is usually the way to go.
             // copy apks to staging dir
             apksToRestore.forEach {
@@ -259,7 +259,7 @@ open class RestoreAppAction(context: Context, shell: ShellHandler) : BaseAppActi
             if (disableVerification) sb.append(" && settings put global verifier_verify_adb_installs 1")
             val command = sb.toString()
             runAsRoot(command)
-            true
+            success = true
             // Todo: Reload package meta data; Package Manager knows everything now; Function missing
         } catch (e: ShellCommandFailedException) {
             val error = e.shellResult.err.joinToString("\n")

--- a/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
@@ -222,7 +222,7 @@ open class RestoreAppAction(context: Context, shell: ShellHandler) : BaseAppActi
             val sb = StringBuilder()
             val disableVerification = context.isDisableVerification
             // disable verify apps over usb
-            if (disableVerification) sb.append("settings put global verifier_verify_adb_installs 0 && ")
+            if (disableVerification) sb.append("settings put global verifier_verify_adb_installs 0 ; ")
             // Install main package
             sb.append(
                 getPackageInstallCommand(
@@ -256,7 +256,7 @@ open class RestoreAppAction(context: Context, shell: ShellHandler) : BaseAppActi
             }"
             )
             // re-enable verify apps over usb
-            if (disableVerification) sb.append(" && settings put global verifier_verify_adb_installs 1")
+            if (disableVerification) sb.append(" ; settings put global verifier_verify_adb_installs 1")
             val command = sb.toString()
             runAsRoot(command)
             success = true


### PR DESCRIPTION
take this example command line:
`settings put global verifier_verify_adb_installs 0 && cat "/data/local/tmp/com.instagram.android.base.apk" | pm install -t -r -S 41020696 ; "/system/bin/toybox" rm "/data/local/tmp/com.instagram.android.base.apk" && settings put global verifier_verify_adb_installs 1`

let's introduce short names to show the structure:
`verifier_0 && cat_apk | pm_install ; rm_apk && verifier_1`

this is equivalent (in bash syntax, not sure if the shell has braces):
```
verifier_0 && { cat_apk | pm_install }
rm_apk && verifier_1
```

so if `verifier_0` fails `pm_install` doesn't happen.
`rm_apk` is executed unconditionally (so the `rm` afterwards in the code isn't necessary and always fails).
But if `rm_apk` fails, `verifier_1` is not executed.

I changed `&&` to `;` at multiple places.
So the sequence is now:
```
verifier_0
cat_apk | pm_install
verifier_1
```
this ensures that
* the verifier is reset to it's former value in all cases.
* `pm_install` is done even if the verifier cannot be disabled, in case it still works


additionally the success condition was wrong:
```
var success = false
success = try {
   ...
   true
} finally {
   if (!success) {
       // failure message
       // cleanup
   }
}
```
`success` is not set before `finally` is finished, so the `if` part is always executed
I replaced this by:
```
var success = false
try {
    ...
    success = true
} finally {
    if (!success)
        // failure message
    // cleanup
}
```

The `if` was used to execute cleanup only in case of failure, but in the command the same cleanup was done (thought to be executed in case of success).
It's more clear to cleanup in all cases at one place. So I removed the condition on success here and removed the other cleanup.