### PR TITLE
TarUtils: check parent directory for all file types, consistent exception handling

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/utils/TarUtils.kt
+++ b/app/src/main/java/com/machiav3lli/backup/utils/TarUtils.kt
@@ -177,7 +177,11 @@ fun TarArchiveInputStream.uncompressTo(targetDir: File?) {
                     }
                 }
                 else -> {
-                    FileOutputStream(targetPath).use { fos -> IOUtils.copy(this, fos) }
+                    try {
+                        FileOutputStream(targetPath).use { fos -> IOUtils.copy(this, fos) }
+                    } catch (e: ErrnoException) {
+                        throw IOException("Unable to create file ${targetPath.absolutePath}: $e")
+                    }
                 }
             }
             if (doChmod) {

--- a/app/src/main/java/com/machiav3lli/backup/utils/TarUtils.kt
+++ b/app/src/main/java/com/machiav3lli/backup/utils/TarUtils.kt
@@ -150,6 +150,10 @@ fun TarArchiveInputStream.uncompressTo(targetDir: File?) {
         generateSequence { nextTarEntry }.forEach { tarEntry ->
             val targetPath = File(it, tarEntry.name)
             Timber.d("Uncompressing ${tarEntry.name} (filesize: ${tarEntry.realSize})")
+            val parent = targetPath.parentFile!!
+            if (!parent.exists() and !parent.mkdirs()) {
+                throw IOException("Unable to create parent folder ${parent.absolutePath}")
+            }
             var doChmod = true
             when {
                 tarEntry.isDirectory -> {
@@ -173,10 +177,6 @@ fun TarArchiveInputStream.uncompressTo(targetDir: File?) {
                     }
                 }
                 else -> {
-                    val parent = targetPath.parentFile!!
-                    if (!parent.exists() and !parent.mkdirs()) {
-                        throw IOException("Unable to create folder ${parent.absolutePath}")
-                    }
                     FileOutputStream(targetPath).use { fos -> IOUtils.copy(this, fos) }
                 }
             }


### PR DESCRIPTION
solves issue #392

dirs, fifos, links etc. cannot be created in a non-existent directory, just like a simple file...so do it for all

additionally, it is better to handle the exception handling consistent for all file types (instead of none for a simple file)