### PR TITLE
remove dependency on test runner (UIThreadStatement)

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/tasks/BaseActionTask.kt
+++ b/app/src/main/java/com/machiav3lli/backup/tasks/BaseActionTask.kt
@@ -19,7 +19,6 @@ package com.machiav3lli.backup.tasks
 
 import android.content.Context
 import android.content.DialogInterface
-import androidx.test.internal.runner.junit4.statement.UiThreadStatement
 import com.machiav3lli.backup.R
 import com.machiav3lli.backup.activities.MainActivityX
 import com.machiav3lli.backup.handler.BackupRestoreHelper.ActionType
@@ -46,7 +45,8 @@ abstract class BaseActionTask(
         val mainActivityX = mainActivityXReference.get()
         if (mainActivityX != null && !mainActivityX.isFinishing) {
             val message = getProgressMessage(mainActivityX, actionType)
-            UiThreadStatement.runOnUiThread {
+            // UiThreadStatement.runOnUiThread {
+            mainActivityX.runOnUiThread {
                 mainActivityX.showSnackBar("${app.packageLabel}: $message")
             }
             showNotification(


### PR DESCRIPTION
The progress bar is updated via runOnUiThread, which is called via the UiThreadSttement class.
UiThreadStatement seems to be defined only in a test runner class.
Not sure why it was used?
The docs say, runOnUiThread should be called on "the" activity.
So I tried that.
At least it works for me (with limited testing, there might be edge cases that I don't have a clue of).