### PR TITLE
Added a simple switch where to place the Wifi config file. Fixes #270

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/items/SpecialAppMetaInfo.kt
+++ b/app/src/main/java/com/machiav3lli/backup/items/SpecialAppMetaInfo.kt
@@ -152,6 +152,12 @@ open class SpecialAppMetaInfo : AppMetaInfo, Parcelable {
                             )
                         )
                     )
+                // Location of the WifiConfigStore had been moved with Android R
+                val wifiConfigLocation = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+                    "/data/misc/wifi/WifiConfigStore.xml"
+                } else {
+                    "/data/misc/apexdata/com.android.wifi/WifiConfigStore.xml"
+                }
                 specialPackages
                     .add(
                         AppInfo(
@@ -160,7 +166,7 @@ open class SpecialAppMetaInfo : AppMetaInfo, Parcelable {
                                 specPrefix + context.getString(R.string.spec_wifiAccessPoints),
                                 Build.VERSION.RELEASE,
                                 Build.VERSION.SDK_INT, arrayOf(
-                                    "/data/misc/wifi/WifiConfigStore.xml"
+                                    wifiConfigLocation
                                 )
                             )
                         )


### PR DESCRIPTION
I was annoyed by the issue #270 and it's a low hanging fruit with just a single if.
I'm restroring my WifiConfigStore.xml for ages on different phones and Android versions, so it should be compatible.

I've seen #375, and I think, it needs some more sophisticated logic and maybe even the mentioned migration strategy to cover all special backups. But let's start small and fix this little issue.