### PR TITLE
More detailed ActionResult messages if ShellCommand failed

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/handler/ShellHandler.kt
+++ b/app/src/main/java/com/machiav3lli/backup/handler/ShellHandler.kt
@@ -129,7 +129,10 @@ class ShellHandler {
         utilBoxQuoted = ""
     }
 
-    class ShellCommandFailedException(@field:Transient val shellResult: Shell.Result) : Exception()
+    class ShellCommandFailedException(
+        @field:Transient val shellResult: Shell.Result,
+        val commands: Array<out String>
+    ) : Exception()
 
     class UnexpectedCommandResult(message: String?, val shellResult: Shell.Result) :
         Exception(message)
@@ -367,7 +370,7 @@ class ShellHandler {
             val result = shell.runCommand(*commands).to(stdout, stderr).exec()
             Timber.d("Command(s) ${commands.joinToString(" ; ")} ended with ${result.code}")
             if (!result.isSuccess)
-                throw ShellCommandFailedException(result)
+                throw ShellCommandFailedException(result, commands)
             return result
         }
 


### PR DESCRIPTION
People often post screenshots of the error dialog in the Telegram group, but we only see the error message.
I've changed backup and restore method to contain the executed command(s) as well, so we can better understand, what's going on.
Not perfect and maybe unclear if there is too much text, but this should rarely be the case.

Here's a example how it looks, if I break the shell command intentionally.
![Screenshot_20211025-215003](https://user-images.githubusercontent.com/5569743/138761130-2f922655-4fdb-42e2-9703-4141c9a73b5a.png)