### PR TITLE
eliminate xxx!! constructs, because they throw unspecified NullPointerExceptions

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/actions/BackupAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/BackupAppAction.kt
@@ -42,7 +42,7 @@ open class BackupAppAction(context: Context, shell: ShellHandler) : BaseAppActio
 
     open fun run(app: AppInfo, backupMode: Int): ActionResult {
         Timber.i("Backing up: ${app.packageName} [${app.packageLabel}]")
-        val appBackupRootUri: Uri? = try {
+        val appBackupRootUri: Uri = try {
             app.getAppUri(context, true)
         } catch (e: BackupLocationIsAccessibleException) {
             // Usually, this should never happen, but just in case...
@@ -72,83 +72,85 @@ open class BackupAppAction(context: Context, shell: ShellHandler) : BaseAppActio
                 false
             )
         }
-        val backupBuilder = BackupBuilder(context, app.appMetaInfo, appBackupRootUri!!)
-        val backupInstanceDir = backupBuilder.backupPath
-        val stopProcess = context.isKillBeforeActionEnabled
-        val backupItem: BackupItem
-        if (stopProcess) {
-            Timber.d("pre-process package (to avoid file inconsistencies during backup etc.)")
-            preprocessPackage(app.packageName)
-        }
-        val iv = initIv(CIPHER_ALGORITHM) // as we're using a static Cipher Algorithm
-        backupBuilder.setIv(iv)
-        try {
-            if (backupMode and MODE_APK == MODE_APK) {
-                Timber.i("$app: Backing up package")
-                backupPackage(app, backupInstanceDir)
-                backupBuilder.setHasApk(true)
-            }
-            var backupCreated: Boolean
-            if (backupMode and MODE_DATA == MODE_DATA) {
-                Timber.i("$app: Backing up data")
-                backupCreated = backupData(app, backupInstanceDir, iv)
-                backupBuilder.setHasAppData(backupCreated)
-            }
-            if (backupMode and MODE_DATA_DE == MODE_DATA_DE) {
-                Timber.i("$app: Backing up device's protected data")
-                backupCreated = backupDeviceProtectedData(app, backupInstanceDir, iv)
-                backupBuilder.setHasDevicesProtectedData(backupCreated)
-            }
-            if (backupMode and MODE_DATA_EXT == MODE_DATA_EXT) {
-                Timber.i("$app: Backing up external data")
-                backupCreated = backupExternalData(app, backupInstanceDir, iv)
-                backupBuilder.setHasExternalData(backupCreated)
-            }
-            if (backupMode and MODE_DATA_OBB == MODE_DATA_OBB) {
-                Timber.i("$app: Backing up obb files")
-                backupCreated = backupObbData(app, backupInstanceDir, iv)
-                backupBuilder.setHasObbData(backupCreated)
-            }
-            if (backupMode and MODE_DATA_MEDIA == MODE_DATA_MEDIA) {
-                Timber.i("$app: Backing up media files")
-                backupCreated = backupMediaData(app, backupInstanceDir, iv)
-                backupBuilder.setHasMediaData(backupCreated)
-            }
-
-            if (context.isEncryptionEnabled()) {
-                backupBuilder.setCipherType(CIPHER_ALGORITHM)
-            }
-            backupItem = backupBuilder.createBackupItem()
-            saveBackupProperties(
-                StorageFile.fromUri(context, appBackupRootUri),
-                backupItem.backupProperties
-            )
-            app.backupHistory.add(backupItem)
-        } catch (e: BackupFailedException) {
-            Timber.e("Backup failed due to ${e.javaClass.simpleName}: ${e.message}")
-            Timber.d("Backup deleted: ${backupBuilder.backupPath?.delete()}")
-            return ActionResult(app, null, "${e.javaClass.simpleName}: ${e.message}", false)
-        } catch (e: CryptoSetupException) {
-            Timber.e("Backup failed due to ${e.javaClass.simpleName}: ${e.message}")
-            Timber.d("Backup deleted: ${backupBuilder.backupPath?.delete()}")
-            return ActionResult(app, null, "${e.javaClass.simpleName}: ${e.message}", false)
-        } catch (e: IOException) {
-            Timber.e("Backup failed due to ${e.javaClass.simpleName}: ${e.message}")
-            Timber.d("Backup deleted: ${backupBuilder.backupPath?.delete()}")
-            return ActionResult(app, null, "${e.javaClass.simpleName}: ${e.message}", false)
-        } catch (e: Throwable) {
-            LogsHandler.unhandledException(e, app)
-            Timber.e("Backup failed due to ${e.javaClass.simpleName}: ${e.message}")
-            Timber.d("Backup deleted: ${backupBuilder.backupPath?.delete()}")
-            return ActionResult(app, null, "${e.javaClass.simpleName}: ${e.message}", false)
-        } finally {
+        val backupBuilder = BackupBuilder(context, app.appMetaInfo, appBackupRootUri)
+        backupBuilder.backupPath?.let { backupInstanceDir ->
+            val stopProcess = context.isKillBeforeActionEnabled
+            val backupItem: BackupItem
             if (stopProcess) {
-                Timber.d("post-process package (to set it back to normal operation)")
-                postprocessPackage(app.packageName)
+                Timber.d("pre-process package (to avoid file inconsistencies during backup etc.)")
+                preprocessPackage(app.packageName)
             }
-        }
-        Timber.i("$app: Backup done: $backupItem")
-        return ActionResult(app, backupItem.backupProperties, "", true)
+            val iv = initIv(CIPHER_ALGORITHM) // as we're using a static Cipher Algorithm
+            backupBuilder.setIv(iv)
+            try {
+                if (backupMode and MODE_APK == MODE_APK) {
+                    Timber.i("$app: Backing up package")
+                    backupPackage(app, backupInstanceDir)
+                    backupBuilder.setHasApk(true)
+                }
+                var backupCreated: Boolean
+                if (backupMode and MODE_DATA == MODE_DATA) {
+                    Timber.i("$app: Backing up data")
+                    backupCreated = backupData(app, backupInstanceDir, iv)
+                    backupBuilder.setHasAppData(backupCreated)
+                }
+                if (backupMode and MODE_DATA_DE == MODE_DATA_DE) {
+                    Timber.i("$app: Backing up device's protected data")
+                    backupCreated = backupDeviceProtectedData(app, backupInstanceDir, iv)
+                    backupBuilder.setHasDevicesProtectedData(backupCreated)
+                }
+                if (backupMode and MODE_DATA_EXT == MODE_DATA_EXT) {
+                    Timber.i("$app: Backing up external data")
+                    backupCreated = backupExternalData(app, backupInstanceDir, iv)
+                    backupBuilder.setHasExternalData(backupCreated)
+                }
+                if (backupMode and MODE_DATA_OBB == MODE_DATA_OBB) {
+                    Timber.i("$app: Backing up obb files")
+                    backupCreated = backupObbData(app, backupInstanceDir, iv)
+                    backupBuilder.setHasObbData(backupCreated)
+                }
+                if (backupMode and MODE_DATA_MEDIA == MODE_DATA_MEDIA) {
+                    Timber.i("$app: Backing up media files")
+                    backupCreated = backupMediaData(app, backupInstanceDir, iv)
+                    backupBuilder.setHasMediaData(backupCreated)
+                }
+
+                if (context.isEncryptionEnabled()) {
+                    backupBuilder.setCipherType(CIPHER_ALGORITHM)
+                }
+                backupItem = backupBuilder.createBackupItem()
+                saveBackupProperties(
+                    StorageFile.fromUri(context, appBackupRootUri),
+                    backupItem.backupProperties
+                )
+                app.backupHistory.add(backupItem)
+            } catch (e: BackupFailedException) {
+                Timber.e("Backup failed due to ${e.javaClass.simpleName}: ${e.message}")
+                Timber.d("Backup deleted: ${backupInstanceDir.delete()}")
+                return ActionResult(app, null, "${e.javaClass.simpleName}: ${e.message}", false)
+            } catch (e: CryptoSetupException) {
+                Timber.e("Backup failed due to ${e.javaClass.simpleName}: ${e.message}")
+                Timber.d("Backup deleted: ${backupInstanceDir.delete()}")
+                return ActionResult(app, null, "${e.javaClass.simpleName}: ${e.message}", false)
+            } catch (e: IOException) {
+                Timber.e("Backup failed due to ${e.javaClass.simpleName}: ${e.message}")
+                Timber.d("Backup deleted: ${backupInstanceDir.delete()}")
+                return ActionResult(app, null, "${e.javaClass.simpleName}: ${e.message}", false)
+            } catch (e: Throwable) {
+                LogsHandler.unhandledException(e, app)
+                Timber.e("Backup failed due to ${e.javaClass.simpleName}: ${e.message}")
+                Timber.d("Backup deleted: ${backupInstanceDir.delete()}")
+                return ActionResult(app, null, "${e.javaClass.simpleName}: ${e.message}", false)
+            } finally {
+                if (stopProcess) {
+                    Timber.d("post-process package (to set it back to normal operation)")
+                    postprocessPackage(app.packageName)
+                }
+            }
+            Timber.i("$app: Backup done: $backupItem")
+            return ActionResult(app, backupItem.backupProperties, "", true)
+        } ?:
+            return ActionResult(app, null, "", true)
     }
 
     @Throws(IOException::class)
@@ -188,8 +190,8 @@ open class BackupAppAction(context: Context, shell: ShellHandler) : BaseAppActio
         val backupFilename = getBackupArchiveFilename(what!!, context.isEncryptionEnabled())
         val backupFile = backupDir.createFile("application/octet-stream", backupFilename)
         val password = context.getEncryptionPassword()
-        val gzipParams = GzipParameters();
-        gzipParams.compressionLevel = context.getCompressionLevel();
+        val gzipParams = GzipParameters()
+        gzipParams.compressionLevel = context.getCompressionLevel()
         var outStream: OutputStream = BufferedOutputStream(
             context.contentResolver.openOutputStream(
                 backupFile?.uri
@@ -227,14 +229,14 @@ open class BackupAppAction(context: Context, shell: ShellHandler) : BaseAppActio
     }
 
     @Throws(BackupFailedException::class)
-    protected open fun backupPackage(app: AppInfo, backupInstanceDir: StorageFile?) {
+    protected open fun backupPackage(app: AppInfo, backupInstanceDir: StorageFile) {
         Timber.i("[${app.packageName}] Backup package apks")
         var apksToBackup = arrayOf(app.apkPath)
         if (app.apkSplits.isEmpty()) {
             Timber.d("[${app.packageName}] The app is a normal apk")
         } else {
             apksToBackup += app.apkSplits.drop(0)
-            Timber.d("[${app.packageName}] Package is splitted into ${apksToBackup.size} apks")
+            Timber.d("[${app.packageName}] Package is split into ${apksToBackup.size} apks")
         }
         Timber.d("[%s] Backing up package (%d apks: %s)",
             app.packageName,
@@ -243,7 +245,7 @@ open class BackupAppAction(context: Context, shell: ShellHandler) : BaseAppActio
         )
         try {
             for (apk in apksToBackup) {
-                suCopyFileToDocument(context.contentResolver, apk, backupInstanceDir!!)
+                suCopyFileToDocument(context.contentResolver, apk, backupInstanceDir)
             }
         } catch (e: IOException) {
             Timber.e("$app: Backup APKs failed: $e")
@@ -297,7 +299,7 @@ open class BackupAppAction(context: Context, shell: ShellHandler) : BaseAppActio
             var dirsInSource = shell.suGetDetailedDirectoryContents(sourceDirectory, false, null)
                 .filter { dir: ShellHandler.FileInfo -> !dir.filename.contains(".gms.") } // a try to exclude google's push notifications id
 
-            // Excludes cache and libs, when we don't want to backup'em
+            // Excludes cache and libs, when we don't want to Cbackup'em
             // TODO maybe remove the option and force the exclusion?
             if (context.getDefaultSharedPreferences().getBoolean(PREFS_EXCLUDECACHE, true)) {
                 dirsInSource = dirsInSource
@@ -337,30 +339,28 @@ open class BackupAppAction(context: Context, shell: ShellHandler) : BaseAppActio
     @Throws(BackupFailedException::class, CryptoSetupException::class)
     protected open fun backupData(
         app: AppInfo,
-        backupInstanceDir: StorageFile?,
+        backupInstanceDir: StorageFile,
         iv: ByteArray?
     ): Boolean {
         val backupType = BACKUP_DIR_DATA
         Timber.i(LOG_START_BACKUP, app.packageName, backupType)
         val filesToBackup = assembleFileList(app.dataPath)
-        return genericBackupData(backupType, backupInstanceDir?.uri, filesToBackup, true, iv)
+        return genericBackupData(backupType, backupInstanceDir.uri, filesToBackup, true, iv)
     }
 
     @Throws(BackupFailedException::class, CryptoSetupException::class)
     protected open fun backupExternalData(
         app: AppInfo,
-        backupInstanceDir: StorageFile?,
+        backupInstanceDir: StorageFile,
         iv: ByteArray?
     ): Boolean {
         val backupType = BACKUP_DIR_EXTERNAL_FILES
         Timber.i(LOG_START_BACKUP, app.packageName, backupType)
         return try {
             val filesToBackup = assembleFileList(app.getExternalDataPath(context))
-            genericBackupData(backupType, backupInstanceDir?.uri, filesToBackup, true, iv)
+            genericBackupData(backupType, backupInstanceDir.uri, filesToBackup, true, iv)
         } catch (ex: BackupFailedException) {
-            if (ex.cause is ShellCommandFailedException
-                && isFileNotFoundException((ex.cause as ShellCommandFailedException?)!!)
-            ) {
+            if (ex.cause is ShellCommandFailedException && isFileNotFoundException(ex.cause)) {
                 // no such data found
                 Timber.i(LOG_NO_THING_TO_BACKUP, backupType, app.packageName)
                 return false
@@ -372,18 +372,16 @@ open class BackupAppAction(context: Context, shell: ShellHandler) : BaseAppActio
     @Throws(BackupFailedException::class, CryptoSetupException::class)
     protected open fun backupObbData(
         app: AppInfo,
-        backupInstanceDir: StorageFile?,
+        backupInstanceDir: StorageFile,
         iv: ByteArray?
     ): Boolean {
         val backupType = BACKUP_DIR_OBB_FILES
         Timber.i(LOG_START_BACKUP, app.packageName, backupType)
         return try {
             val filesToBackup = assembleFileList(app.getObbFilesPath(context))
-            genericBackupData(backupType, backupInstanceDir?.uri, filesToBackup, false, iv)
+            genericBackupData(backupType, backupInstanceDir.uri, filesToBackup, false, iv)
         } catch (ex: BackupFailedException) {
-            if (ex.cause is ShellCommandFailedException
-                && isFileNotFoundException((ex.cause as ShellCommandFailedException?)!!)
-            ) {
+            if (ex.cause is ShellCommandFailedException && isFileNotFoundException(ex.cause)) {
                 // no such data found
                 Timber.i(LOG_NO_THING_TO_BACKUP, backupType, app.packageName)
                 return false
@@ -395,18 +393,16 @@ open class BackupAppAction(context: Context, shell: ShellHandler) : BaseAppActio
     @Throws(BackupFailedException::class, CryptoSetupException::class)
     protected open fun backupMediaData(
         app: AppInfo,
-        backupInstanceDir: StorageFile?,
+        backupInstanceDir: StorageFile,
         iv: ByteArray?
     ): Boolean {
         val backupType = BACKUP_DIR_MEDIA_FILES
         Timber.i(LOG_START_BACKUP, app.packageName, backupType)
         return try {
             val filesToBackup = assembleFileList(app.getMediaFilesPath(context))
-            genericBackupData(backupType, backupInstanceDir?.uri, filesToBackup, false, iv)
+            genericBackupData(backupType, backupInstanceDir.uri, filesToBackup, false, iv)
         } catch (ex: BackupFailedException) {
-            if (ex.cause is ShellCommandFailedException
-                && isFileNotFoundException((ex.cause as ShellCommandFailedException?)!!)
-            ) {
+            if (ex.cause is ShellCommandFailedException && isFileNotFoundException(ex.cause)) {
                 // no such data found
                 Timber.i(LOG_NO_THING_TO_BACKUP, backupType, app.packageName)
                 return false
@@ -418,18 +414,16 @@ open class BackupAppAction(context: Context, shell: ShellHandler) : BaseAppActio
     @Throws(BackupFailedException::class, CryptoSetupException::class)
     protected open fun backupDeviceProtectedData(
         app: AppInfo,
-        backupInstanceDir: StorageFile?,
+        backupInstanceDir: StorageFile,
         iv: ByteArray?
     ): Boolean {
         val backupType = BACKUP_DIR_DEVICE_PROTECTED_FILES
         Timber.i(LOG_START_BACKUP, app.packageName, backupType)
         return try {
             val filesToBackup = assembleFileList(app.devicesProtectedDataPath)
-            genericBackupData(backupType, backupInstanceDir?.uri, filesToBackup, true, iv)
+            genericBackupData(backupType, backupInstanceDir.uri, filesToBackup, true, iv)
         } catch (ex: BackupFailedException) {
-            if (ex.cause is ShellCommandFailedException
-                && isFileNotFoundException((ex.cause as ShellCommandFailedException?)!!)
-            ) {
+            if (ex.cause is ShellCommandFailedException && isFileNotFoundException(ex.cause)) {
                 // no such data found
                 Timber.i(LOG_NO_THING_TO_BACKUP, backupType, app.packageName)
                 return false

--- a/app/src/main/java/com/machiav3lli/backup/actions/BackupAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/BackupAppAction.kt
@@ -180,14 +180,14 @@ open class BackupAppAction(context: Context, shell: ShellHandler) : BaseAppActio
 
     @Throws(IOException::class, CryptoSetupException::class)
     protected fun createBackupArchive(
-        backupInstanceDir: Uri?,
-        what: String?,
+        backupInstanceDir: Uri,
+        what: String,
         allFilesToBackup: List<ShellHandler.FileInfo>,
         iv: ByteArray?
     ) {
         Timber.i("Creating $what backup")
-        val backupDir = StorageFile.fromUri(context, backupInstanceDir!!)
-        val backupFilename = getBackupArchiveFilename(what!!, context.isEncryptionEnabled())
+        val backupDir = StorageFile.fromUri(context, backupInstanceDir)
+        val backupFilename = getBackupArchiveFilename(what, context.isEncryptionEnabled())
         val backupFile = backupDir.createFile("application/octet-stream", backupFilename)
         val password = context.getEncryptionPassword()
         val gzipParams = GzipParameters()
@@ -219,12 +219,12 @@ open class BackupAppAction(context: Context, shell: ShellHandler) : BaseAppActio
 
     @Throws(IOException::class)
     protected fun copyToBackupArchive(
-        backupInstanceDir: Uri?,
-        what: String?,
+        backupInstanceDir: Uri,
+        what: String,
         allFilesToBackup: List<ShellHandler.FileInfo>
     ) {
-        val backupInstance = StorageFile.fromUri(context, backupInstanceDir!!)
-        val backupDir = backupInstance.createDirectory(what!!)
+        val backupInstance = StorageFile.fromUri(context, backupInstanceDir)
+        val backupDir = backupInstance.createDirectory(what)
         suRecursiveCopyFileToDocument(context, allFilesToBackup, backupDir?.uri ?: Uri.EMPTY)
     }
 
@@ -258,8 +258,8 @@ open class BackupAppAction(context: Context, shell: ShellHandler) : BaseAppActio
 
     @Throws(BackupFailedException::class, CryptoSetupException::class)
     protected fun genericBackupData(
-        backupType: String?,
-        backupInstanceDir: Uri?,
+        backupType: String,
+        backupInstanceDir: Uri,
         filesToBackup: List<ShellHandler.FileInfo>,
         compress: Boolean,
         iv: ByteArray?

--- a/app/src/main/java/com/machiav3lli/backup/fragments/AppSheet.kt
+++ b/app/src/main/java/com/machiav3lli/backup/fragments/AppSheet.kt
@@ -308,16 +308,17 @@ class AppSheet(val appInfo: AppInfo, var appExtras: AppExtras, val position: Int
                     viewModel.refreshNow.value = true
                 } catch (e: ShellCommands.ShellActionFailedException) {
                     // Not a critical issue
-                    val errorMessage: String? = when (e.cause) {
-                        is ShellHandler.ShellCommandFailedException -> {
-                            (e.cause as ShellHandler.ShellCommandFailedException?)?.shellResult?.err?.joinToString(
-                                " "
-                            )
+                    val errorMessage: String =
+                        when (e.cause) {
+                            is ShellHandler.ShellCommandFailedException -> {
+                                e.cause.shellResult.err.joinToString(
+                                    " "
+                                )
+                            }
+                            else -> {
+                                e.cause?.message ?: "unknown error"
+                            }
                         }
-                        else -> {
-                            e.cause?.message
-                        }
-                    }
                     Timber.w("Cache couldn't be deleted: $errorMessage")
                 }
             }

--- a/app/src/main/java/com/machiav3lli/backup/handler/NotificationHandler.kt
+++ b/app/src/main/java/com/machiav3lli/backup/handler/NotificationHandler.kt
@@ -44,7 +44,7 @@ fun showNotification(context: Context?, parentActivity: Class<out BaseActivity?>
             .setSmallIcon(R.drawable.ic_app)
             .setContentTitle(title)
             .setStyle(if (bigText.isEmpty()) null
-            else NotificationCompat.BigTextStyle().bigText(bigText))
+                      else NotificationCompat.BigTextStyle().bigText(bigText))
             .setContentText(if (text.isNullOrEmpty()) null else text)
             .setAutoCancel(autoCancel)
             .setContentIntent(resultPendingIntent)

--- a/app/src/main/java/com/machiav3lli/backup/items/BackupProperties.kt
+++ b/app/src/main/java/com/machiav3lli/backup/items/BackupProperties.kt
@@ -184,7 +184,7 @@ open class BackupProperties : AppMetaInfo, Parcelable {
         var hash = 7
         hash = 31 * hash + backupDate.hashCode()
         hash = 31 * hash + if (hasApk) 1 else 0
-        hash = 31 * hash + if (hasAppData) 1 else 0
+        hash = 31 * hash + if (hasAppData) 1 else 0                 
         hash = 31 * hash + if (hasDevicesProtectedData) 1 else 0
         hash = 31 * hash + if (hasExternalData) 1 else 0
         hash = 31 * hash + if (hasObbData) 1 else 0

--- a/app/src/main/java/com/machiav3lli/backup/tasks/AppActionWork.kt
+++ b/app/src/main/java/com/machiav3lli/backup/tasks/AppActionWork.kt
@@ -79,22 +79,22 @@ class AppActionWork(val context: Context, workerParams: WorkerParameters) :
         try {
             appInfo?.let { ai ->
                 try {
-                    result = when {
-                        backupBoolean -> {
-                            BackupRestoreHelper.backup(
-                                context,
-                                MainActivityX.shellHandlerInstance!!,
-                                ai,
-                                selectedMode
-                            )
-                        }
-                        else -> {
-                            // Latest backup for now
-                            ai.latestBackup?.let {
-                                BackupRestoreHelper.restore(
-                                    context, MainActivityX.shellHandlerInstance!!, ai, selectedMode,
-                                    it.backupProperties, it.backupInstanceDirUri
-                                )
+                    MainActivityX.shellHandlerInstance?.let { instance ->
+                        result = when {
+                            backupBoolean ->
+                                {
+                                    BackupRestoreHelper.backup(
+                                        context, instance, ai, selectedMode
+                                    )
+                                }
+                            else -> {
+                                // Latest backup for now
+                                ai.latestBackup?.let {
+                                    BackupRestoreHelper.restore(
+                                        context, instance, ai, selectedMode,
+                                        it.backupProperties, it.backupInstanceDirUri
+                                    )
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/machiav3lli/backup/utils/DocumentUtils.kt
+++ b/app/src/main/java/com/machiav3lli/backup/utils/DocumentUtils.kt
@@ -106,11 +106,11 @@ fun suCopyFileToDocument(
     targetDir: StorageFile
 ) {
     val newFile = targetDir.createFile("application/octet-stream", sourceFile.filename)
-    if (newFile != null)
-        resolver.openOutputStream(newFile.uri).use { outputFile ->
-            ShellHandler.quirkLibsuReadFileWorkaround(sourceFile, outputFile!!)
-        }
-    else
+    if (newFile != null) {
+        resolver.openOutputStream(newFile.uri)?.use { outputFile ->
+            ShellHandler.quirkLibsuReadFileWorkaround(sourceFile, outputFile)
+        } ?: throw IOException()
+    } else
         throw IOException()
 }
 
@@ -119,12 +119,12 @@ fun suRecursiveCopyFileFromDocument(context: Context, sourceDir: Uri, targetPath
     val resolver = context.contentResolver
     val rootDir = StorageFile.fromUri(context, sourceDir)
     for (sourceDoc in rootDir.listFiles()) {
-        if (sourceDoc.isDirectory) {
-            runAsRoot("mkdir -p ${quote(File(targetPath, sourceDoc.name!!))}")
-        } else if (sourceDoc.isFile) {
-            suCopyFileFromDocument(
-                resolver, sourceDoc.uri, File(targetPath, sourceDoc.name!!).absolutePath
-            )
+        sourceDoc.name?.also {
+            if (sourceDoc.isDirectory) {
+                runAsRoot("mkdir -p ${quote(File(targetPath, it))}")
+            } else if (sourceDoc.isFile) {
+                suCopyFileFromDocument(resolver, sourceDoc.uri, File(targetPath, it).absolutePath)
+            }
         }
     }
 }

--- a/app/src/main/java/com/machiav3lli/backup/utils/FileUtils.kt
+++ b/app/src/main/java/com/machiav3lli/backup/utils/FileUtils.kt
@@ -28,8 +28,8 @@ object FileUtils {
     private var backupLocation: Uri? = null
 
     // TODO Change to StorageFile-based
-    fun getExternalStorageDirectory(context: Context): File {
-        return context.getExternalFilesDir(null)!!.parentFile!!.parentFile!!.parentFile!!.parentFile!!
+    fun getExternalStorageDirectory(context: Context): File? {
+        return context.getExternalFilesDir(null)?.parentFile?.parentFile?.parentFile?.parentFile
     }
 
     /**

--- a/app/src/main/java/com/machiav3lli/backup/utils/PrefUtils.kt
+++ b/app/src/main/java/com/machiav3lli/backup/utils/PrefUtils.kt
@@ -88,7 +88,7 @@ fun Context.setEncryptionPasswordConfirmation(value: String) =
     getPrivateSharedPrefs().edit().putString(PREFS_PASSWORD_CONFIRMATION, value).commit()
 
 fun Context.getCompressionLevel() =
-    getDefaultSharedPreferences().getInt(PREFS_COMPRESSION_LEVEL, 5);
+    getDefaultSharedPreferences().getInt(PREFS_COMPRESSION_LEVEL, 5)
 
 fun Context.isDeviceLockEnabled(): Boolean =
     getDefaultSharedPreferences().getBoolean(PREFS_DEVICELOCK, false)
@@ -222,7 +222,7 @@ private fun Activity.requireWriteStoragePermission() {
 val Context.canAccessExternalStorage: Boolean
     get() {
         val externalStorage = FileUtils.getExternalStorageDirectory(this)
-        return externalStorage.canRead() && externalStorage.canWrite()
+        return externalStorage?.let { it.canRead() && it.canWrite() } ?: false
     }
 
 val Context.checkUsageStatsPermission: Boolean

--- a/app/src/main/java/com/machiav3lli/backup/utils/TarUtils.kt
+++ b/app/src/main/java/com/machiav3lli/backup/utils/TarUtils.kt
@@ -150,10 +150,11 @@ fun TarArchiveInputStream.uncompressTo(targetDir: File?) {
         generateSequence { nextTarEntry }.forEach { tarEntry ->
             val targetPath = File(it, tarEntry.name)
             Timber.d("Uncompressing ${tarEntry.name} (filesize: ${tarEntry.realSize})")
-            val parent = targetPath.parentFile!!
-            if (!parent.exists() and !parent.mkdirs()) {
-                throw IOException("Unable to create parent folder ${parent.absolutePath}")
-            }
+            targetPath.parentFile?.let {
+                if (!it.exists() and !it.mkdirs()) {
+                    throw IOException("Unable to create parent folder ${it.absolutePath}")
+                }
+            } ?: throw IOException("No parent folder for ${targetPath.absolutePath}")
             var doChmod = true
             var postponeChmod = false
             when {

--- a/app/src/main/java/com/machiav3lli/backup/viewmodels/AppSheetViewModel.kt
+++ b/app/src/main/java/com/machiav3lli/backup/viewmodels/AppSheetViewModel.kt
@@ -23,17 +23,17 @@ import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.machiav3lli.backup.activities.MainActivityX
+import com.machiav3lli.backup.handler.LogsHandler
 import com.machiav3lli.backup.handler.ShellCommands
 import com.machiav3lli.backup.handler.showNotification
 import com.machiav3lli.backup.items.AppInfo
 import com.machiav3lli.backup.items.BackupItem
-import com.machiav3lli.backup.handler.LogsHandler
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
-class AppSheetViewModel(app: AppInfo, var shellCommands: ShellCommands?, private val appContext: Application)
+class AppSheetViewModel(app: AppInfo, var shellCommands: ShellCommands, private val appContext: Application)
     : AndroidViewModel(appContext) {
 
     var appInfo = MediatorLiveData<AppInfo>()
@@ -59,7 +59,7 @@ class AppSheetViewModel(app: AppInfo, var shellCommands: ShellCommands?, private
             appInfo.value?.let {
                 Timber.i("uninstalling: ${appInfo.value?.packageLabel}")
                 try {
-                    shellCommands?.uninstall(appInfo.value?.packageName, appInfo.value?.apkPath,
+                    shellCommands.uninstall(appInfo.value?.packageName, appInfo.value?.apkPath,
                             appInfo.value?.dataPath, appInfo.value?.isSystem == true)
                     showNotification(appContext, MainActivityX::class.java, notificationId++, appInfo.value?.packageLabel,
                             appContext.getString(com.machiav3lli.backup.R.string.uninstallSuccess), true)
@@ -83,12 +83,12 @@ class AppSheetViewModel(app: AppInfo, var shellCommands: ShellCommands?, private
     @Throws(ShellCommands.ShellActionFailedException::class)
     private suspend fun enableDisable(users: MutableList<String>, enable: Boolean) {
         withContext(Dispatchers.IO) {
-            shellCommands!!.enableDisablePackage(appInfo.value?.packageName, users, enable)
+            shellCommands.enableDisablePackage(appInfo.value?.packageName, users, enable)
         }
     }
 
     fun getUsers(): Array<String> {
-        return shellCommands?.getUsers()?.toTypedArray() ?: arrayOf()
+        return shellCommands.getUsers()?.toTypedArray() ?: arrayOf()
     }
 
     fun deleteBackup(backup: BackupItem) {

--- a/app/src/main/java/com/machiav3lli/backup/viewmodels/AppSheetViewModelFactory.kt
+++ b/app/src/main/java/com/machiav3lli/backup/viewmodels/AppSheetViewModelFactory.kt
@@ -23,7 +23,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.machiav3lli.backup.handler.ShellCommands
 import com.machiav3lli.backup.items.AppInfo
 
-class AppSheetViewModelFactory(private val app: AppInfo, private val shellCommands: ShellCommands?, private val application: Application)
+class AppSheetViewModelFactory(private val app: AppInfo, private val shellCommands: ShellCommands, private val application: Application)
     : ViewModelProvider.Factory {
     @Suppress("unchecked_cast")
     override fun <T : ViewModel?> create(modelClass: Class<T>): T {

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -299,7 +299,6 @@
     <string name="prefs_accent_2">Índigo tranquilo</string>
     <string name="prefs_accent_1">Púrpura fino</string>
     <string name="prefs_accent_0">Rojo cometa</string>
-    <string name="update_all">Actualizar todo</string>
     <string name="sortBackupDate">Fecha de respaldo</string>
     <string name="backup_all_updated">Respaldar todas las aplicaciones actualizadas</string>
     <string name="prefs_mediadata_summary">Respalda y restaura los archivos de medios de la aplicación que estén situados en el almacenamiento externo (ej. /storage/emulated/0/Android/media/)</string>


### PR DESCRIPTION
Java→Kotlin conversion added many xxx!! constructs, that throw NullPointerExceptions, which don't say much about why they happen (file not found? backup directory not existent? etc.).

This is the first part of reducing such `xxx!!` constructs.

Please review this thoroughly.
Would be nice if more developers involved with the original code could have an eye on it (e.g. @Tiefkuehlpizze).

For each occurrence, I tried to do formal transformations that keep the semantic, and do the right thing in other cases, but I don't have insights in all the decisions according to the code. May be, some things are intentionally.

You should probably look at the changes with a more capable visual diff program (like `meld` or `windiff`), that can show diffs inside a line or ignore whitespace changes, because the changes are usually smaller than it looks on github.
E.g.
```
val file = File(filePath!!)
val isDirSource = filePath.endsWith("/")
val parent = if (isDirSource) file.name else null
...
```
is replaced by
```
filePath?.let { path ->
    val file = File(path)
    val isDirSource = filePath.endsWith("/")
    val parent = if (isDirSource) file.name else null
    ...
}
```
The entire block is wrapped by the `?.let {}` construct, which only changes the indent for most of the lines.

If I find more time, I will probably continue the process, but I will create another PR for that.
This one is finished from my POV.