### PR TITLE
separate excluded dirs and cache

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/actions/BackupAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/BackupAppAction.kt
@@ -300,9 +300,12 @@ open class BackupAppAction(context: Context, shell: ShellHandler) : BaseAppActio
 
             // Excludes cache and libs, when we don't want to backup'em
             // TODO maybe remove the option and force the exclusion?
+            dirsInSource = dirsInSource
+                .filter { dir: ShellHandler.FileInfo -> !DATA_EXCLUDED_DIRS.contains(dir.filename) }
+                .toList()
             if (context.getDefaultSharedPreferences().getBoolean(PREFS_EXCLUDECACHE, true)) {
                 dirsInSource = dirsInSource
-                    .filter { dir: ShellHandler.FileInfo -> !DATA_EXCLUDED_DIRS.contains(dir.filename) }
+                    .filter { dir: ShellHandler.FileInfo -> !DATA_EXCLUDED_CACHE_DIRS.contains(dir.filename) }
                     .toList()
             }
 

--- a/app/src/main/java/com/machiav3lli/backup/actions/BaseAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/BaseAppAction.kt
@@ -104,7 +104,8 @@ abstract class BaseAppAction protected constructor(
          @machiav3lli libs are generally created while installing the app. Backing them up
           would result a compatibility problem between devices with different cpu_arch
          */
-        val DATA_EXCLUDED_DIRS = listOf("cache", "code_cache", "lib")
+        val DATA_EXCLUDED_CACHE_DIRS = listOf("cache", "code_cache")
+        val DATA_EXCLUDED_DIRS = listOf("lib")
         private val doNotStop = listOf(
             "com.android.shell",  // don't remove this
             BuildConfig.APPLICATION_ID, // ignore own package

--- a/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
@@ -371,7 +371,7 @@ open class RestoreAppAction(context: Context, shell: ShellHandler) : BaseAppActi
                     wipeDirectory(
                         targetDir,
                         DATA_EXCLUDED_DIRS
-                    ) //TODO hg: isn't it inconsistent, if we keep cache*? and what about "lib", why isn't it in the backup?
+                    )
                     // Move all the extracted data into the target directory
                     val command =
                         "$utilBoxQuoted mv -f ${quote(it.toString())}/* ${quote(targetDir)}/"
@@ -417,6 +417,7 @@ open class RestoreAppAction(context: Context, shell: ShellHandler) : BaseAppActi
                 mutableListOf(*shell.suGetDirectoryContents(targetDir))
             // Maybe dirty: Remove what we don't wanted to have in the backup. Just don't touch it
             dataContents.removeAll(DATA_EXCLUDED_DIRS)
+            dataContents.removeAll(DATA_EXCLUDED_CACHE_DIRS)
             // calculate a list what must be updated
             val chownTargets = dataContents.map { s -> File(targetDir, s).absolutePath }
             if (chownTargets.isEmpty()) {


### PR DESCRIPTION
This separates the exclusion of cache* and lib from the backup. Both were dependent on the backup cache setting, but only cache* should (as the name says).

It also removes the exclusion of the cache from wiping at restore.
I think the cache is invalid after a restore, so it should be wiped, right?

As I don't restore with OABX on my daily driver currently, and my other phones are used for other projects, I cannot test this.
But I think the functionallity of the patch is obvious. 