### PR TITLE
AVD doesn't like the newline after the shift command. Remove it.

### DIFF
--- a/app/src/main/assets/files/package.sh
+++ b/app/src/main/assets/files/package.sh
@@ -1,41 +1,27 @@
 command=$1
 shift
-
 utilbox=$1
 shift
-
 suspend=false
-
 while [[ $1 == --* ]]; do
-
   if [[ $1 == --suspend ]]; then
     shift
     suspend=true
     continue
   fi
-
   break
-
 done
-
-
 if [[ $command == "pre" ]]; then
-
   package=$1
   shift
-
   userid=$1
   shift
-
-
   #am force-stop $package
   #am kill $package
-
   if $suspend; then
     pm suspend $package >/dev/null
     $utilbox sleep 3
   fi
-
   pids=$(
     (
       $utilbox ps -o PID -u $userid | $utilbox tail -n +2
@@ -46,9 +32,7 @@ if [[ $command == "pre" ]]; then
     ) |
     $utilbox sort -u -n
   )
-
   #echo "pids=( $pids )"
-
   if [[ -n $pids ]]; then
     $utilbox ps -A -w -o USER,PID,NAME -p $pids |
       while read -r user pid process; do
@@ -58,25 +42,17 @@ if [[ $command == "pre" ]]; then
         $utilbox kill -STOP $pid && echo $pid
       done
   fi
-
   exit
 fi
-
 if [[ $command == "post" ]]; then
-
   package=$1
   shift
-
   userid=$1
   shift
-
   am kill $package
-
   if [[ -n $* ]]; then $utilbox kill -CONT "$@"; fi
-
   if $suspend; then
     pm unsuspend $package
   fi
-
   exit
 fi

--- a/app/src/main/assets/files/tar.sh
+++ b/app/src/main/assets/files/tar.sh
@@ -1,52 +1,35 @@
 command=$1
 shift
-
 utilbox=$1
 shift
-
 archive=-
 exclude=
-
 while [[ $1 == --* ]]; do
-
   if [[ $1 == --archive ]]; then
     shift
     archive=$1
     shift
     continue
   fi
-
   if [[ $1 == --exclude ]]; then
     shift
     exclude="$exclude -X $1"
     shift
     continue
   fi
-
   break
-
 done
-
-
 if [[ $command == "create" ]]; then
-
   dir=$1
   shift
-
   #cd $dir && (
   #  ($utilbox ls -1A | $utilbox tar -c -f "$archive" $exclude -T -) || (dd if=/dev/zero bs=1024c count=1 2>/dev/null)
   #)
   $utilbox tar -c -f "$archive" -C "$dir" $exclude .
-
   exit $?
-
 elif [[ $command == "extract" ]]; then
-
   dir=$1
   shift
-
   $utilbox tar -x -f "$archive" -C "$dir" $exclude
-
   exit $?
 fi
-


### PR DESCRIPTION
AVD has issues with empty line after a shift command. Remove all empty lines to fix this