### PR TITLE
strict hard links, more root shadow paths

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
@@ -373,7 +373,10 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
                         targetPath,
                         DATA_EXCLUDED_DIRS
                     )
-                    archiveStream.suUnpackTo(RootFile(targetPath))
+                    archiveStream.suUnpackTo(
+                        RootFile(targetPath),
+                        getDefaultSharedPreferences(MainActivityX.activity)
+                            .getBoolean("strictHardLinks", false))
                 } else {
                     // Create a temporary directory in OABX's cache directory and uncompress the data into it
                     Files.createTempDirectory(cachePath?.toPath(), "restore_")?.let {

--- a/app/src/main/java/com/machiav3lli/backup/activities/MainActivityX.kt
+++ b/app/src/main/java/com/machiav3lli/backup/activities/MainActivityX.kt
@@ -23,10 +23,12 @@ import android.app.PendingIntent
 import android.content.*
 import android.content.res.AssetManager
 import android.os.Bundle
+import android.os.Looper
 import android.os.PersistableBundle
 import android.os.Process
 import android.view.MenuItem
 import android.view.View
+import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
@@ -303,12 +305,7 @@ class MainActivityX : BaseActivity() {
                                 "\n${BuildConfig.APPLICATION_ID} ${BuildConfig.VERSION_NAME}\n" +
                                 runAsRoot("logcat --pid=${Process.myPid()}").out.joinToString("\n")
                     )
-                    startActivity(
-                        Intent.makeRestartActivityTask(
-                            ComponentName(this, PrefsActivity::class.java)
-                        )
-                    )
-                    /*object : Thread() {
+                    object : Thread() {
                         override fun run() {
                             Looper.prepare()
                             repeat(5) {
@@ -322,7 +319,6 @@ class MainActivityX : BaseActivity() {
                         }
                     }.start()
                     Thread.sleep(5000)
-                    */
                 } finally {
                     System.exit(2)
                 }

--- a/app/src/main/java/com/machiav3lli/backup/items/StorageFile.kt
+++ b/app/src/main/java/com/machiav3lli/backup/items/StorageFile.kt
@@ -52,9 +52,11 @@ open class StorageFile {
                                 val (storage, subpath) = last.split(":")
                                 val possiblePaths = listOf(
                                     "/storage/$storage/$subpath",
+                                    "/storage/self/$storage/$subpath",
                                     "/mnt/media_rw/$storage/$subpath",
                                     "/mnt/runtime/full/$storage/$subpath",
-                                    "/mnt/runtime/default/$storage/$subpath"
+                                    "/mnt/runtime/default/$storage/$subpath",
+                                    "/mnt/runtime/default/self/$storage/$subpath"
                                 )
                                 var checkFile: RootFile? = null
                                 for(path in possiblePaths) {

--- a/app/src/main/java/com/machiav3lli/backup/utils/TarUtils.kt
+++ b/app/src/main/java/com/machiav3lli/backup/utils/TarUtils.kt
@@ -146,7 +146,7 @@ fun TarArchiveOutputStream.suAddFiles(allFiles: List<ShellHandler.FileInfo>) {
 }
 
 @Throws(IOException::class, ShellCommandFailedException::class)
-fun TarArchiveInputStream.suUnpackTo(targetDir: RootFile?) {
+fun TarArchiveInputStream.suUnpackTo(targetDir: RootFile?, strictHardLinks: Boolean = false) {
     val qUtilBox = ShellHandler.utilBoxQ
     targetDir?.let {
         val postponeModes = mutableMapOf<String, Int>()
@@ -167,8 +167,10 @@ fun TarArchiveInputStream.suUnpackTo(targetDir: RootFile?) {
                     postponeChmod = true
                 }
                 tarEntry.isLink -> {
+
                     runAsRoot(
-                        "$qUtilBox ln ${quote(tarEntry.linkName)} ${quote(targetPath)}"
+                        // OABX v7 implementation stroes hard links and extracts all links as symlinks
+                        "$qUtilBox ln ${if(strictHardLinks) "" else "-s"} ${quote(tarEntry.linkName)} ${quote(targetPath)}"
                     )
                     doChmod = false
                 }

--- a/app/src/main/res/xml/preferences_advanced.xml
+++ b/app/src/main/res/xml/preferences_advanced.xml
@@ -61,7 +61,7 @@
         android:title="pauseApps" />
 
     <androidx.preference.CheckBoxPreference
-        android:defaultValue="true"
+        android:defaultValue="false"
         android:key="pmSuspend"
         android:summary="additionally use pm suspend command to pause apps"
         android:title="pmSuspend" />
@@ -77,6 +77,12 @@
         android:key="restoreTarCmd"
         android:summary="use tar shell command for restore"
         android:title="restoreTarCmd" />
+
+    <androidx.preference.CheckBoxPreference
+        android:defaultValue="false"
+        android:key="strictHardLinks"
+        android:summary="for API tar only: unpack hard links as hard links (otherwise they become symlinks)"
+        android:title="strictHardLinks" />
 
     <androidx.preference.CheckBoxPreference
         android:defaultValue="true"


### PR DESCRIPTION
this is mainly to increase compatibility with v7 backups.

Original v7 tarapi saved symlinks as hardlinks and restored each link as symlink.

v8 restores symlinks as symlinks and hardlinks as hardlinks (as it should be, ideally).

To be compatible to v7 backups, I added an option strictHardLinks that is disabled by default.
As a result extracting v7 backups is supported by default.

BUT:
v8 still handles obb and media as plain tar files (without compression), while v7 saved them by simply copying the file tree. Because this had some errors, I didn't add compatibility (no urgent need to fix those issues).

So, to restore v7 backups, obb and media must be disabled.
Instead obb and media fo v7 backups can simply be restored with the original v7 apk.


This PR also contains more search paths to shadow SAF by RootFile.
Newer Androids use these.