### PR TITLE
fix catchUncaughtException, logcat was hanging, disable restoreAvoidTemporaryCopy by default (it's much faster for many files)

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/activities/MainActivityX.kt
+++ b/app/src/main/java/com/machiav3lli/backup/activities/MainActivityX.kt
@@ -302,8 +302,11 @@ class MainActivityX : BaseActivity() {
                     LogsHandler.unhandledException(e)
                     LogsHandler(context).writeToLogFile(
                         "uncaught exception happened:\n\n" +
-                                "\n${BuildConfig.APPLICATION_ID} ${BuildConfig.VERSION_NAME}\n" +
-                                runAsRoot("logcat --pid=${Process.myPid()}").out.joinToString("\n")
+                                "\n${BuildConfig.APPLICATION_ID} ${BuildConfig.VERSION_NAME}"
+                                + "\n" +
+                                runAsRoot(
+                                    "logcat -d --pid=${Process.myPid()}"  // -d = dump and exit
+                                ).out.joinToString("\n")
                     )
                     object : Thread() {
                         override fun run() {

--- a/app/src/main/res/xml/preferences_advanced.xml
+++ b/app/src/main/res/xml/preferences_advanced.xml
@@ -85,7 +85,7 @@
         android:title="strictHardLinks" />
 
     <androidx.preference.CheckBoxPreference
-        android:defaultValue="true"
+        android:defaultValue="false"
         android:key="restoreAvoidTemporaryCopy"
         android:summary="for API tar only: avoid using a temporary directory to extract files"
         android:title="restoreAvoidTemporaryCopy" />


### PR DESCRIPTION
the `logcat` command was missing the `-d`, without it runs infinitely (like tail). I swear it worked at some point :-) I got a new adb version, may be that changed the behavior (but only guessing)