### PR TITLE
fix: deleteallbackups+uncaughtExceptions+restoreAvoidTemporaryCopy

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/activities/MainActivityX.kt
+++ b/app/src/main/java/com/machiav3lli/backup/activities/MainActivityX.kt
@@ -302,8 +302,11 @@ class MainActivityX : BaseActivity() {
                     LogsHandler.unhandledException(e)
                     LogsHandler(context).writeToLogFile(
                         "uncaught exception happened:\n\n" +
-                                "\n${BuildConfig.APPLICATION_ID} ${BuildConfig.VERSION_NAME}\n" +
-                                runAsRoot("logcat --pid=${Process.myPid()}").out.joinToString("\n")
+                                "\n${BuildConfig.APPLICATION_ID} ${BuildConfig.VERSION_NAME}"
+                                + "\n" +
+                                runAsRoot(
+                                    "logcat -d --pid=${Process.myPid()}"  // -d = dump and exit
+                                ).out.joinToString("\n")
                     )
                     object : Thread() {
                         override fun run() {

--- a/app/src/main/java/com/machiav3lli/backup/items/StorageFile.kt
+++ b/app/src/main/java/com/machiav3lli/backup/items/StorageFile.kt
@@ -52,11 +52,15 @@ open class StorageFile {
                                 val (storage, subpath) = last.split(":")
                                 val possiblePaths = listOf(
                                     "/storage/$storage/$subpath",
-                                    "/storage/self/$storage/$subpath",
                                     "/mnt/media_rw/$storage/$subpath",
                                     "/mnt/runtime/full/$storage/$subpath",
                                     "/mnt/runtime/default/$storage/$subpath",
+                                    "/storage/self/$storage/$subpath",
                                     "/mnt/runtime/default/self/$storage/$subpath"
+                                    // these would need user number
+                                    //"/mnt/user/$user/$storage/$subpath",
+                                    //"/mnt/user/$user/self/$storage/$subpath",
+                                    //"/mnt/androidwritable/$user/self/$storage/$subpath",
                                 )
                                 var checkFile: RootFile? = null
                                 for(path in possiblePaths) {
@@ -172,8 +176,7 @@ open class StorageFile {
     fun delete(): Boolean {
         return try {
             file?.let {
-                //it.delete()  does not work, becaujse using "rmdir -f"
-                ShellUtils.fastCmdResult("rm -f ${quote(it)} || rmdir ${quote(it)}")
+                it.deleteRecursive()
             } ?: DocumentsContract.deleteDocument(context!!.contentResolver, uri!!)
         } catch (e: FileNotFoundException) {
             false

--- a/app/src/main/res/xml/preferences_advanced.xml
+++ b/app/src/main/res/xml/preferences_advanced.xml
@@ -85,7 +85,7 @@
         android:title="strictHardLinks" />
 
     <androidx.preference.CheckBoxPreference
-        android:defaultValue="true"
+        android:defaultValue="false"
         android:key="restoreAvoidTemporaryCopy"
         android:summary="for API tar only: avoid using a temporary directory to extract files"
         android:title="restoreAvoidTemporaryCopy" />


### PR DESCRIPTION
* "delete all backups" of a package didn't work (and also deleting the last backup) because in case of the last backup the whole package dir was removed and this used another way to delete it, which couldn't delete recursively

* the `logcat` command was missing the `-d`. Without this logcat works like tail (running infinitely). I swear it worked at some point :-) I got a new adb version, may be that changed the behavior (but only guessing)

* default for restoreAvoidTemporaryDirectory is false, because it's much faster with tarapi (and it's not used for tarcmd)