### PR TITLE
fix hanging rootfile, WorkHandler, AssetHandler, use app for globals and early init

### DIFF
--- a/app/src/androidTest/kotlin/tests/Test_BackupRestore.kt
+++ b/app/src/androidTest/kotlin/tests/Test_BackupRestore.kt
@@ -91,7 +91,7 @@ class Test_BackupRestore {
     @Before
     fun init() {
         tempStorage = StorageFile(tempDir)
-        shellHandler = ShellHandler(context)
+        shellHandler = ShellHandler()
         backupDirTarApi = tempStorage.createDirectory("backup_tarapi")
         backupDirTarCmd = tempStorage.createDirectory("backup_tarcmd")
         archiveTarApi = StorageFile(backupDirTarApi, "data.tar.gz")

--- a/app/src/androidTest/kotlin/tests/Test_selinux.kt
+++ b/app/src/androidTest/kotlin/tests/Test_selinux.kt
@@ -10,7 +10,7 @@ class Test_selinux {
     @Test
     fun test_suGetOwnerGroupContext_extracts_valid_context() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        val userGroupContext = ShellHandler(context).suGetOwnerGroupContext("/system")
+        val userGroupContext = ShellHandler().suGetOwnerGroupContext("/system")
         val con = userGroupContext[2]
         Timber.i("suGetOwnerGroupContext -> ${userGroupContext.joinToString("', '", "'", "'")} => context = '$con'")
 

--- a/app/src/androidTest/kotlin/tests/Test_selinux.kt
+++ b/app/src/androidTest/kotlin/tests/Test_selinux.kt
@@ -1,7 +1,7 @@
 package tests
+import androidx.test.platform.app.InstrumentationRegistry
 import com.machiav3lli.backup.handler.ShellHandler
-import org.junit.Assert.assertNotEquals
-import org.junit.Assert.assertNotNull
+import org.junit.Assert.*
 import org.junit.Test
 import timber.log.Timber
 
@@ -9,12 +9,14 @@ class Test_selinux {
 
     @Test
     fun test_suGetOwnerGroupContext_extracts_valid_context() {
-        val userGroupContext = ShellHandler().suGetOwnerGroupContext("/")
-        val context = userGroupContext[2]
-        Timber.i("suGetOwnerGroupContext -> ${userGroupContext.joinToString("', '", "'", "'")} => context = '$context'")
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val userGroupContext = ShellHandler(context).suGetOwnerGroupContext("/system")
+        val con = userGroupContext[2]
+        Timber.i("suGetOwnerGroupContext -> ${userGroupContext.joinToString("', '", "'", "'")} => context = '$con'")
 
-        assertNotNull(context)
-        assertNotEquals("?", context)
+        assertNotNull(con)
+        assertNotEquals("?", con)
+        assertEquals("u:object_r:system_file:s0", con)
     }
 
 }

--- a/app/src/androidTest/kotlin/tests/Test_shell.kt
+++ b/app/src/androidTest/kotlin/tests/Test_shell.kt
@@ -96,7 +96,9 @@ class Test_shell {
                 dump(
                     ShellHandler.FileInfo.unescapeLsOutput(
                         runAsRoot("toybox ls -bdAlZ $testPattern")
-                            .out.joinToString("\n").split(" ", limit = 9)[8]
+                            .out.joinToString("\n")
+                            .split(Regex(" +"), limit = 9)
+                                [8]
                     )
                 )
             )

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -87,7 +87,7 @@
 
         <receiver android:name=".services.AlarmReceiver" />
 
-        <receiver android:name=".activities.MainActivityX$Companion$WorkReceiver" />
+        <receiver android:name=".services.WorkReceiver" />
 
         <service
             android:name=".services.ScheduleService"

--- a/app/src/main/java/com/machiav3lli/backup/OABX.kt
+++ b/app/src/main/java/com/machiav3lli/backup/OABX.kt
@@ -38,6 +38,11 @@ class OABX : Application() {
 
         val context: Context    get() = app.applicationContext
         val work: WorkHandler   get() = app.work!!
+
+        fun prefFlag(name: String, default: Boolean) =
+                        PreferenceManager.getDefaultSharedPreferences(context).getBoolean(name, default)
+        fun prefInt(name: String, default: Int) =
+                        PreferenceManager.getDefaultSharedPreferences(context).getInt(name, default)
     }
 
     override fun onCreate() {

--- a/app/src/main/java/com/machiav3lli/backup/OABX.kt
+++ b/app/src/main/java/com/machiav3lli/backup/OABX.kt
@@ -18,15 +18,38 @@
 package com.machiav3lli.backup
 
 import android.app.Application
+import android.content.Context
 import android.util.LruCache
+import androidx.preference.PreferenceManager
+import com.machiav3lli.backup.handler.WorkHandler
 import com.machiav3lli.backup.items.AppInfo
 import timber.log.Timber
+import java.lang.ref.WeakReference
 
 class OABX : Application() {
+
     var cache: LruCache<String, MutableList<AppInfo>> = LruCache(4000)
+
+    var work: WorkHandler? = null
+
+    companion object {
+        var appRef: WeakReference<OABX> = WeakReference(null)
+        val app: OABX           get() = appRef.get()!!
+
+        val context: Context    get() = app.applicationContext
+        val work: WorkHandler   get() = app.work!!
+    }
 
     override fun onCreate() {
         super.onCreate()
+        appRef = WeakReference(this)
         Timber.plant(Timber.DebugTree())
+        work = WorkHandler(context)
+    }
+
+    override fun onTerminate() {
+        work = work?.release()
+        appRef = WeakReference(null)
+        super.onTerminate()
     }
 }

--- a/app/src/main/java/com/machiav3lli/backup/OABX.kt
+++ b/app/src/main/java/com/machiav3lli/backup/OABX.kt
@@ -21,6 +21,7 @@ import android.app.Application
 import android.content.Context
 import android.util.LruCache
 import androidx.preference.PreferenceManager
+import com.machiav3lli.backup.handler.ShellHandler
 import com.machiav3lli.backup.handler.WorkHandler
 import com.machiav3lli.backup.items.AppInfo
 import timber.log.Timber
@@ -36,11 +37,24 @@ class OABX : Application() {
         var appRef: WeakReference<OABX> = WeakReference(null)
         val app: OABX           get() = appRef.get()!!
 
+        var shellHandlerInstance: ShellHandler? = null
+            private set
+
+        fun initShellHandler() : Boolean {
+            return try {
+                shellHandlerInstance = ShellHandler()
+                true
+            } catch (e: ShellHandler.ShellCommandFailedException) {
+                false
+            }
+        }
+
         val context: Context    get() = app.applicationContext
         val work: WorkHandler   get() = app.work!!
 
         fun prefFlag(name: String, default: Boolean) =
                         PreferenceManager.getDefaultSharedPreferences(context).getBoolean(name, default)
+
         fun prefInt(name: String, default: Int) =
                         PreferenceManager.getDefaultSharedPreferences(context).getInt(name, default)
     }
@@ -49,6 +63,7 @@ class OABX : Application() {
         super.onCreate()
         appRef = WeakReference(this)
         Timber.plant(Timber.DebugTree())
+        initShellHandler()
         work = WorkHandler(context)
     }
 

--- a/app/src/main/java/com/machiav3lli/backup/actions/BackupAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/BackupAppAction.kt
@@ -19,9 +19,7 @@ package com.machiav3lli.backup.actions
 
 import android.annotation.SuppressLint
 import android.content.Context
-import androidx.preference.PreferenceManager
 import com.machiav3lli.backup.*
-import com.machiav3lli.backup.activities.MainActivityX
 import com.machiav3lli.backup.handler.BackupBuilder
 import com.machiav3lli.backup.handler.LogsHandler
 import com.machiav3lli.backup.handler.ShellHandler
@@ -483,9 +481,7 @@ open class BackupAppAction(context: Context, work: AppActionWork?, shell: ShellH
         compress: Boolean,
         iv: ByteArray?
     ): Boolean {
-            if (PreferenceManager.getDefaultSharedPreferences(MainActivityX.activity)
-                    .getBoolean("backupTarCmd", true)
-            ) {
+            if (OABX.prefFlag("backupTarCmd", true)) {
                 return genericBackupDataTarCmd(
                     dataType,
                     backupInstanceDir,

--- a/app/src/main/java/com/machiav3lli/backup/actions/BackupAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/BackupAppAction.kt
@@ -267,16 +267,16 @@ open class BackupAppAction(context: Context, work: AppActionWork?, shell: ShellH
             apksToBackup.size,
             apksToBackup.joinToString(" ") { s: String -> RootFile(s).name }
         )
-        try {
-            for (apk in apksToBackup) {
+        for (apk in apksToBackup) {
+            try {
                 suCopyFileToDocument(apk, backupInstanceDir)
+            } catch (e: IOException) {
+                Timber.e("$app: Could not backup apk $apk: $e")
+                throw BackupFailedException("Could not backup apk $apk", e)
+            } catch (e: Throwable) {
+                LogsHandler.unhandledException(e, app)
+                throw BackupFailedException("Could not backup apk $apk", e)
             }
-        } catch (e: IOException) {
-            Timber.e("$app: Backup APKs failed: $e")
-            throw BackupFailedException("Could not backup apk", e)
-        } catch (e: Throwable) {
-            LogsHandler.unhandledException(e, app)
-            throw BackupFailedException("Could not backup apk", e)
         }
     }
 

--- a/app/src/main/java/com/machiav3lli/backup/actions/BackupAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/BackupAppAction.kt
@@ -211,7 +211,7 @@ open class BackupAppAction(context: Context, work: AppActionWork?, shell: ShellH
         iv: ByteArray?
     ) {
         Timber.i("Creating $what backup via API")
-        val backupFilename = getBackupArchiveFilename(what, compress, context.isEncryptionEnabled())
+        val backupFilename = getBackupArchiveFilename(what, compress, iv != null && context.isEncryptionEnabled())
         val backupFile = backupInstanceDir.createFile("application/octet-stream", backupFilename)
 
         val password = context.getEncryptionPassword()
@@ -220,7 +220,7 @@ open class BackupAppAction(context: Context, work: AppActionWork?, shell: ShellH
 
         var outStream: OutputStream = backupFile.outputStream()!!
 
-        if (password.isNotEmpty() && context.isEncryptionEnabled()) {
+        if (iv != null && password.isNotEmpty() && context.isEncryptionEnabled()) {
             outStream = outStream.encryptStream(password, context.getCryptoSalt(), iv)
         }
         if(compress) {
@@ -394,7 +394,7 @@ open class BackupAppAction(context: Context, work: AppActionWork?, shell: ShellH
         if(!ShellUtils.fastCmdResult("test -d ${quote(sourcePath)}"))
             return false
         Timber.i("Creating $dataType backup via tar")
-        val backupFilename = getBackupArchiveFilename(dataType, compress, context.isEncryptionEnabled())
+        val backupFilename = getBackupArchiveFilename(dataType, compress, iv != null && context.isEncryptionEnabled())
         val backupFile = backupInstanceDir.createFile("application/octet-stream", backupFilename)
 
         val password = context.getEncryptionPassword()
@@ -403,7 +403,7 @@ open class BackupAppAction(context: Context, work: AppActionWork?, shell: ShellH
 
         var outStream: OutputStream = backupFile.outputStream()!!
 
-        if (password.isNotEmpty() && context.isEncryptionEnabled()) {
+        if (iv != null && password.isNotEmpty() && context.isEncryptionEnabled()) {
             outStream = outStream.encryptStream(password, context.getCryptoSalt(), iv)
         }
         if(compress) {

--- a/app/src/main/java/com/machiav3lli/backup/actions/BackupAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/BackupAppAction.kt
@@ -424,8 +424,9 @@ open class BackupAppAction(context: Context, work: AppActionWork?, shell: ShellH
             if (context.getDefaultSharedPreferences().getBoolean(PREFS_EXCLUDECACHE, true)) {
                 options += " --exclude ${quote(excludeCache)}"
             }
+            var suOptions = "--mount-master"
 
-            val cmd = "su --mount-master -c sh ${quote(tarScript)} create $utilBoxQ ${options} ${quote(sourcePath)}"
+            val cmd = "su $suOptions -c sh ${quote(tarScript)} create $utilBoxQ ${options} ${quote(sourcePath)}"
             Timber.i("SHELL: $cmd")
 
             val process = Runtime.getRuntime().exec(cmd)

--- a/app/src/main/java/com/machiav3lli/backup/actions/BaseAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/BaseAppAction.kt
@@ -19,9 +19,8 @@ package com.machiav3lli.backup.actions
 
 import android.content.Context
 import android.content.pm.PackageManager
-import androidx.preference.PreferenceManager
 import com.machiav3lli.backup.BuildConfig
-import com.machiav3lli.backup.activities.MainActivityX
+import com.machiav3lli.backup.OABX
 import com.machiav3lli.backup.handler.LogsHandler
 import com.machiav3lli.backup.handler.ShellHandler
 import com.machiav3lli.backup.handler.ShellHandler.Companion.runAsRoot
@@ -51,9 +50,7 @@ abstract class BaseAppAction protected constructor(
     }
 
     private fun prepostOptions() : String {
-        return if (PreferenceManager.getDefaultSharedPreferences(MainActivityX.activity)
-                    .getBoolean("pmSuspend", true)
-                  ) { "--suspend" } else { "" }
+        return if (OABX.prefFlag("pmSuspend", true)) { "--suspend" } else { "" }
     }
 
     open fun preprocessPackage(packageName: String) {

--- a/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
@@ -450,9 +450,10 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
                     ) {
                         options += " --exclude " + quote(excludeCache)
                     }
+                    var suOptions = "--mount-master"
 
                     val cmd =
-                        "su --mount-master -c sh $qTarScript extract $utilBoxQ ${options} ${quote(targetDir)}"
+                        "su $suOptions -c sh $qTarScript extract $utilBoxQ ${options} ${quote(targetDir)}"
                     Timber.i("SHELL: $cmd")
 
                     val process = Runtime.getRuntime().exec(cmd)

--- a/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
@@ -604,6 +604,10 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
             throw RestoreFailedException(
                 "path '$extractTo' does not contain ${app.packageName}"
             )
+
+        if(!RootFile(extractTo).isDirectory)
+            throw RestoreFailedException("directory '$extractTo' does not exist")
+
         // retrieve the assigned uid and gid from the data directory Android created
         val uidgidcon = shell.suGetOwnerGroupContext(extractTo)
         genericRestoreFromArchive(
@@ -648,6 +652,10 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
             throw RestoreFailedException(
                 "path '$extractTo' does not contain ${app.packageName}"
             )
+
+        if(!RootFile(extractTo).isDirectory)
+            throw RestoreFailedException("directory '$extractTo' does not exist")
+
         // retrieve the assigned uid and gid from the data directory Android created
         val uidgidcon = shell.suGetOwnerGroupContext(extractTo)
         genericRestoreFromArchive(

--- a/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
@@ -18,10 +18,7 @@
 package com.machiav3lli.backup.actions
 
 import android.content.Context
-import androidx.preference.PreferenceManager
-import androidx.preference.PreferenceManager.getDefaultSharedPreferences
 import com.machiav3lli.backup.*
-import com.machiav3lli.backup.activities.MainActivityX
 import com.machiav3lli.backup.handler.LogsHandler
 import com.machiav3lli.backup.handler.ShellHandler
 import com.machiav3lli.backup.handler.ShellHandler.Companion.findAssetFile
@@ -365,18 +362,13 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
             TarArchiveInputStream(
                 openArchiveFile(archive, compressed, isEncrypted, iv)
             ).use { archiveStream ->
-                if(getDefaultSharedPreferences(MainActivityX.activity)
-                        .getBoolean("restoreAvoidTemporaryCopy", true)
-                ) {
+                if(OABX.prefFlag("restoreAvoidTemporaryCopy", true)) {
                     // clear the data from the final directory
                     wipeDirectory(
                         targetPath,
                         DATA_EXCLUDED_DIRS
                     )
-                    archiveStream.suUnpackTo(
-                        RootFile(targetPath),
-                        getDefaultSharedPreferences(MainActivityX.activity)
-                            .getBoolean("strictHardLinks", false))
+                    archiveStream.suUnpackTo(RootFile(targetPath), OABX.prefFlag("strictHardLinks", false))
                 } else {
                     // Create a temporary directory in OABX's cache directory and uncompress the data into it
                     Files.createTempDirectory(cachePath?.toPath(), "restore_")?.let {
@@ -519,9 +511,7 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
         iv: ByteArray?,
         cachePath: RootFile?
     ) {
-        if (PreferenceManager.getDefaultSharedPreferences(MainActivityX.activity)
-                .getBoolean("restoreTarCmd", true)
-        ) {
+        if (OABX.prefFlag("restoreTarCmd", true)) {
             return genericRestoreFromArchiveTarCmd(
                 dataType,
                 archive,
@@ -836,7 +826,7 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
         val sleepTimeMs = 1000L
 
         // delay before first try
-        val delayMs = context.getDefaultSharedPreferences().getInt("delayBeforeRefreshAppInfo", 0) * 1000L
+        val delayMs = OABX.prefInt("delayBeforeRefreshAppInfo", 0) * 1000L
         var timeWaitedMs = 0L
         do {
             Thread.sleep(sleepTimeMs)
@@ -845,7 +835,7 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
 
         // try multiple times to get valid paths from PackageManager
         // maxWaitMs is cumulated sleep time between tries
-        val maxWaitMs = context.getDefaultSharedPreferences().getInt("refreshAppInfoTimeout", 30) * 1000L
+        val maxWaitMs = OABX.prefInt("refreshAppInfoTimeout", 30) * 1000L
         timeWaitedMs = 0L
         var attemptNo = 0
         do {

--- a/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
@@ -332,7 +332,7 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
         var inputStream: InputStream = BufferedInputStream(archive.inputStream()!!)
         if (isEncrypted) {
             val password = context.getEncryptionPassword()
-            if (password.isNotEmpty() && context.isEncryptionEnabled()) {
+            if (iv != null && password.isNotEmpty() && context.isEncryptionEnabled()) {
                 Timber.d("Decryption enabled")
                 inputStream = inputStream.decryptStream(password, context.getCryptoSalt(), iv)
             }

--- a/app/src/main/java/com/machiav3lli/backup/actions/RestoreSpecialAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/RestoreSpecialAction.kt
@@ -29,7 +29,6 @@ import com.machiav3lli.backup.items.SpecialAppMetaInfo
 import com.machiav3lli.backup.items.StorageFile
 import com.machiav3lli.backup.tasks.AppActionWork
 import com.machiav3lli.backup.utils.CryptoSetupException
-import com.machiav3lli.backup.utils.isEncryptionEnabled
 import com.machiav3lli.backup.utils.unpackTo
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
 import org.apache.commons.io.FileUtils
@@ -63,7 +62,7 @@ class RestoreSpecialAction(context: Context, work: AppActionWork?, shell: ShellH
         Timber.i("%s: Restore special data", app)
         val metaInfo = app.appMetaInfo as SpecialAppMetaInfo
         val tempPath = File(context.cacheDir, backupProperties.packageName ?: "")
-        val isEncrypted = context.isEncryptionEnabled()
+        val isEncrypted = backupProperties.isEncrypted
         val backupArchiveFilename = getBackupArchiveFilename(BACKUP_DIR_DATA, compressed, isEncrypted)
         val backupArchiveFile = backupDir.findFile(backupArchiveFilename)
             ?: throw RestoreFailedException("Backup archive at $backupArchiveFilename is missing")

--- a/app/src/main/java/com/machiav3lli/backup/activities/MainActivityX.kt
+++ b/app/src/main/java/com/machiav3lli/backup/activities/MainActivityX.kt
@@ -20,7 +20,6 @@ package com.machiav3lli.backup.activities
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
-import android.content.Context
 import android.content.DialogInterface
 import android.content.Intent
 import android.content.SharedPreferences
@@ -46,7 +45,6 @@ import com.machiav3lli.backup.dbs.BlocklistDatabase
 import com.machiav3lli.backup.fragments.ProgressViewController
 import com.machiav3lli.backup.fragments.RefreshViewController
 import com.machiav3lli.backup.handler.LogsHandler
-import com.machiav3lli.backup.handler.ShellHandler
 import com.machiav3lli.backup.handler.ShellHandler.Companion.runAsRoot
 import com.machiav3lli.backup.items.SortFilterModel
 import com.machiav3lli.backup.items.StorageFile
@@ -62,18 +60,6 @@ import java.lang.ref.WeakReference
 class MainActivityX : BaseActivity() {
 
     companion object {
-
-        var shellHandlerInstance: ShellHandler? = null
-            private set
-
-        fun initShellHandler(context: Context) : Boolean {
-            return try {
-                shellHandlerInstance = ShellHandler(context)
-                true
-            } catch (e: ShellHandler.ShellCommandFailedException) {
-                false
-            }
-        }
 
         var activityRef : WeakReference<MainActivityX> = WeakReference(null)
         var activity : MainActivityX?
@@ -295,7 +281,6 @@ class MainActivityX : BaseActivity() {
         viewModel.refreshNow.observe(this, {
             if (it) refreshView()
         })
-        initShell()
         runOnUiThread { showEncryptionDialog() }
         setContentView(binding.root)
     }
@@ -389,16 +374,6 @@ class MainActivityX : BaseActivity() {
                     )
                 }
                 .show()
-        }
-    }
-
-    private fun initShell() {
-        // Initialize the ShellHandler for further root checks
-        if (!initShellHandler(this)) {
-            showWarning(
-                MainActivityX::class.java.simpleName,
-                getString(R.string.shell_initproblem)
-            ) { _: DialogInterface?, _: Int -> finishAffinity() }
         }
     }
 

--- a/app/src/main/java/com/machiav3lli/backup/activities/MainActivityX.kt
+++ b/app/src/main/java/com/machiav3lli/backup/activities/MainActivityX.kt
@@ -245,8 +245,7 @@ class MainActivityX : BaseActivity() {
         setCustomTheme()
         super.onCreate(savedInstanceState)
 
-        if(PreferenceManager.getDefaultSharedPreferences(context)
-                .getBoolean("catchUncaughtException", true)) {
+        if(OABX.prefFlag("catchUncaughtException", true)) {
             Thread.setDefaultUncaughtExceptionHandler { thread, e ->
                 try {
                     LogsHandler.unhandledException(e)

--- a/app/src/main/java/com/machiav3lli/backup/activities/MainActivityX.kt
+++ b/app/src/main/java/com/machiav3lli/backup/activities/MainActivityX.kt
@@ -97,8 +97,7 @@ class MainActivityX : BaseActivity() {
                 var workBlocked = 0
                 var workRunning = 0
                 var workFinished = 0
-                var workSecondAttempts = 0
-                var workLastAttempts = 0
+                var workRetries = 0
                 var succeeded = 0
                 var failed = 0
                 var canceled = 0
@@ -108,10 +107,7 @@ class MainActivityX : BaseActivity() {
                     val operation = progress.getString("operation")
                     workCount++
                     if (workInfo.runAttemptCount > 1) {
-                        if (workInfo.runAttemptCount == AppActionWork.WORK_MAX_ATTEMPTS)
-                            workLastAttempts++
-                        else
-                            workSecondAttempts++
+                        workRetries++
                     }
 
                     when(workInfo.state) {
@@ -152,7 +148,12 @@ class MainActivityX : BaseActivity() {
                 }
 
                 val processed = succeeded + failed
-                val title = "$processed/$workCount = ✔$succeeded/❌$failed (🔄$workSecondAttempts...$workLastAttempts) ⏸$workBlocked ⏹$canceled - $queued🚀$running"
+
+                var title = "+$succeeded -$failed / $workCount"
+                    if(running+queued > 0)
+                        title += "  🏃$running 👭${queued}"
+                    else
+                        title += "  ${OABX.context.getString(R.string.finished)}"
 
                 if(workCount>0) {
                     val notificationManager = NotificationManagerCompat.from(appContext)

--- a/app/src/main/java/com/machiav3lli/backup/activities/SplashActivity.kt
+++ b/app/src/main/java/com/machiav3lli/backup/activities/SplashActivity.kt
@@ -20,7 +20,6 @@ package com.machiav3lli.backup.activities
 import android.content.Intent
 import android.os.Bundle
 import android.os.PowerManager
-import com.machiav3lli.backup.BuildConfig
 import com.machiav3lli.backup.PREFS_FIRST_LAUNCH
 import com.machiav3lli.backup.PREFS_IGNORE_BATTERY_OPTIMIZATION
 import com.machiav3lli.backup.classAddress
@@ -30,19 +29,6 @@ import com.topjohnwu.superuser.Shell
 
 class SplashActivity : BaseActivity() {
     private lateinit var binding: ActivitySplashBinding
-
-    companion object {
-        init {
-            // Shell.Config methods shall be called before any shell is created
-            Shell.enableVerboseLogging = BuildConfig.DEBUG
-            Shell.setDefaultBuilder(
-                Shell.Builder.create()
-                        //.setInitializers(BusyBoxInstaller::class.java)
-                        .setFlags(Shell.FLAG_MOUNT_MASTER)
-                        .setTimeout(20)
-            )
-        }
-    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         setCustomTheme()

--- a/app/src/main/java/com/machiav3lli/backup/fragments/AppSheet.kt
+++ b/app/src/main/java/com/machiav3lli/backup/fragments/AppSheet.kt
@@ -36,7 +36,6 @@ import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.chip.Chip
 import com.google.android.material.chip.ChipDrawable
 import com.machiav3lli.backup.*
-import com.machiav3lli.backup.activities.MainActivityX
 import com.machiav3lli.backup.databinding.SheetAppBinding
 import com.machiav3lli.backup.dbs.AppExtras
 import com.machiav3lli.backup.dialogs.BackupDialogFragment
@@ -44,7 +43,10 @@ import com.machiav3lli.backup.dialogs.RestoreDialogFragment
 import com.machiav3lli.backup.handler.BackupRestoreHelper.ActionType
 import com.machiav3lli.backup.handler.ShellCommands
 import com.machiav3lli.backup.handler.ShellHandler
-import com.machiav3lli.backup.items.*
+import com.machiav3lli.backup.items.AppInfo
+import com.machiav3lli.backup.items.BackupItemX
+import com.machiav3lli.backup.items.BackupProperties
+import com.machiav3lli.backup.items.HomeItemX
 import com.machiav3lli.backup.tasks.BackupActionTask
 import com.machiav3lli.backup.tasks.RestoreActionTask
 import com.machiav3lli.backup.utils.*
@@ -389,7 +391,7 @@ class AppSheet(val appInfo: AppInfo, var appExtras: AppExtras, val position: Int
             when {
                 actionType === ActionType.BACKUP -> {
                     BackupActionTask(
-                        it, requireMainActivity(), MainActivityX.shellHandlerInstance!!, mode,
+                        it, requireMainActivity(), OABX.shellHandlerInstance!!, mode,
                         this
                     ).execute()
                 }
@@ -397,7 +399,7 @@ class AppSheet(val appInfo: AppInfo, var appExtras: AppExtras, val position: Int
                     backupProps?.let { backupProps: BackupProperties ->
                         val backupDir = backupProps.getBackupDir(viewModel.appInfo.value?.backupDir)
                         RestoreActionTask(
-                            it, requireMainActivity(), MainActivityX.shellHandlerInstance!!, mode,
+                            it, requireMainActivity(), OABX.shellHandlerInstance!!, mode,
                             backupProps, backupDir!!, this
                         ).execute()
                     }

--- a/app/src/main/java/com/machiav3lli/backup/fragments/BatchFragment.kt
+++ b/app/src/main/java/com/machiav3lli/backup/fragments/BatchFragment.kt
@@ -333,7 +333,7 @@ open class BatchFragment(private val backupBoolean: Boolean) : NavigationFragmen
         var resultsSuccess = true
         var counter = 0
         val worksList: MutableList<OneTimeWorkRequest> = mutableListOf()
-        MainActivityX.startWork()
+        MainActivityX.startWork(requireContext())
         selectedItems.forEach { (packageName, mode) ->
 
             val oneTimeWorkRequest =

--- a/app/src/main/java/com/machiav3lli/backup/fragments/BatchFragment.kt
+++ b/app/src/main/java/com/machiav3lli/backup/fragments/BatchFragment.kt
@@ -35,6 +35,7 @@ import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import com.machiav3lli.backup.MAIN_FILTER_DEFAULT
+import com.machiav3lli.backup.OABX
 import com.machiav3lli.backup.R
 import com.machiav3lli.backup.activities.MainActivityX
 import com.machiav3lli.backup.databinding.FragmentBatchBinding
@@ -333,7 +334,7 @@ open class BatchFragment(private val backupBoolean: Boolean) : NavigationFragmen
         var resultsSuccess = true
         var counter = 0
         val worksList: MutableList<OneTimeWorkRequest> = mutableListOf()
-        MainActivityX.startWork(requireContext())
+        OABX.work.startBatch()
         selectedItems.forEach { (packageName, mode) ->
 
             val oneTimeWorkRequest =

--- a/app/src/main/java/com/machiav3lli/backup/fragments/HomeFragment.kt
+++ b/app/src/main/java/com/machiav3lli/backup/fragments/HomeFragment.kt
@@ -272,7 +272,7 @@ class HomeFragment : NavigationFragment(),
         var counter = 0
         val worksList: MutableList<OneTimeWorkRequest> = mutableListOf()
         val workManager = WorkManager.getInstance(requireContext())
-        MainActivityX.startWork(requireContext())
+        OABX.work.startBatch()
         selectedItems.forEach { (packageName, mode) ->
 
             val oneTimeWorkRequest =

--- a/app/src/main/java/com/machiav3lli/backup/fragments/HomeFragment.kt
+++ b/app/src/main/java/com/machiav3lli/backup/fragments/HomeFragment.kt
@@ -272,7 +272,7 @@ class HomeFragment : NavigationFragment(),
         var counter = 0
         val worksList: MutableList<OneTimeWorkRequest> = mutableListOf()
         val workManager = WorkManager.getInstance(requireContext())
-        MainActivityX.startWork()
+        MainActivityX.startWork(requireContext())
         selectedItems.forEach { (packageName, mode) ->
 
             val oneTimeWorkRequest =

--- a/app/src/main/java/com/machiav3lli/backup/fragments/PrefsServiceFragment.kt
+++ b/app/src/main/java/com/machiav3lli/backup/fragments/PrefsServiceFragment.kt
@@ -103,13 +103,14 @@ class PrefsServiceFragment : PreferenceFragmentCompat() {
 
     private fun onPrefChangePassword(
         passwordConfirmation: EditTextPreference,
-        password: String,
-        passwordCheck: String
+        password: String?,
+        passwordCheck: String?
     ): Boolean {
         passwordConfirmation.summary =
-            if (password == passwordCheck) getString(R.string.prefs_password_match_true) else getString(
-                R.string.prefs_password_match_false
-            )
+            if (password == passwordCheck)
+                getString(R.string.prefs_password_match_true)
+            else
+                getString(R.string.prefs_password_match_false)
         return true
     }
 }

--- a/app/src/main/java/com/machiav3lli/backup/fragments/PrefsServiceFragment.kt
+++ b/app/src/main/java/com/machiav3lli/backup/fragments/PrefsServiceFragment.kt
@@ -48,9 +48,10 @@ class PrefsServiceFragment : PreferenceFragmentCompat() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         passwordConfirmationPref.summary =
-            if (passwordPref.text == passwordConfirmationPref.text) getString(R.string.prefs_password_match_true) else getString(
-                R.string.prefs_password_match_false
-            )
+            if (passwordPref.text == passwordConfirmationPref.text)
+                getString(R.string.prefs_password_match_true)
+            else
+                getString(R.string.prefs_password_match_false)
         passwordPref.setOnBindEditTextListener {
             it.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD
         }

--- a/app/src/main/java/com/machiav3lli/backup/fragments/PrefsToolsFragment.kt
+++ b/app/src/main/java/com/machiav3lli/backup/fragments/PrefsToolsFragment.kt
@@ -26,7 +26,6 @@ import androidx.fragment.app.Fragment
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import com.machiav3lli.backup.*
-import com.machiav3lli.backup.activities.MainActivityX
 import com.machiav3lli.backup.activities.PrefsActivity
 import com.machiav3lli.backup.handler.BackupRestoreHelper
 import com.machiav3lli.backup.handler.ExportsHandler
@@ -139,7 +138,7 @@ class PrefsToolsFragment : PreferenceFragmentCompat() {
             GlobalScope.launch(Dispatchers.IO) {
                 if (BackupRestoreHelper.copySelfApk(
                         requireContext(),
-                        MainActivityX.shellHandlerInstance!!
+                        OABX.shellHandlerInstance!!
                     )
                 )
                     showNotification(

--- a/app/src/main/java/com/machiav3lli/backup/handler/AssetHandler.kt
+++ b/app/src/main/java/com/machiav3lli/backup/handler/AssetHandler.kt
@@ -1,0 +1,74 @@
+package com.machiav3lli.backup.handler
+
+import android.content.Context
+import android.content.res.AssetManager
+import com.machiav3lli.backup.BuildConfig
+import com.machiav3lli.backup.actions.BaseAppAction
+import timber.log.Timber
+import java.io.File
+import java.io.FileOutputStream
+
+class AssetHandler(context: Context) {
+
+    val VERSION_FILE = "__version__"
+    val ASSETS_SUBDIR = "assets"
+
+    lateinit var directory : File
+        private set
+
+    init {
+        // copy scripts to file storage
+        directory = File(context.filesDir, ASSETS_SUBDIR)
+        directory.mkdirs()
+        // don't copy if the files exist and are from the current app version
+        val appVersion = BuildConfig.VERSION_NAME
+        val version = try {
+            File(directory, VERSION_FILE).readText()
+        } catch (e: Throwable) {
+            ""
+        }
+        if (version != appVersion) {
+            try {
+                // cleans assetDir and copiers asset files
+                context.assets.copyRecursively("files", directory)
+                // additional generated files
+                File(directory, ShellHandler.EXCLUDE_FILE)
+                    .writeText(
+                        (BaseAppAction.DATA_EXCLUDED_DIRS.map { "./$it" } + BaseAppAction.DATA_EXCLUDED_FILES)
+                            .map { it + "\n" }.joinToString("")
+                    )
+                File(directory, ShellHandler.EXCLUDE_CACHE_FILE)
+                    .writeText(
+                        BaseAppAction.DATA_EXCLUDED_CACHE_DIRS.map { "./$it" }
+                            .map { it + "\n" }.joinToString("")
+                    )
+                // validate with version file if completed
+                File(directory, VERSION_FILE).writeText(appVersion)
+            } catch (e: Throwable) {
+                Timber.w("cannot copy scripts to ${directory}")
+            }
+        }
+    }
+
+}
+
+fun AssetManager.copyRecursively(assetPath: String, targetFile: File) {
+    list(assetPath)?.let { list ->
+        if (list.isEmpty()) { // assetPath is file
+            open(assetPath).use { input ->
+                FileOutputStream(targetFile.absolutePath).use { output ->
+                    input.copyTo(output)
+                    output.flush()
+                }
+            }
+
+        } else { // assetPath is folder
+            targetFile.deleteRecursively()
+            targetFile.mkdir()
+
+            list.forEach {
+                copyRecursively("$assetPath/$it", File(targetFile, it))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/machiav3lli/backup/handler/ShellCommands.kt
+++ b/app/src/main/java/com/machiav3lli/backup/handler/ShellCommands.kt
@@ -152,6 +152,7 @@ class ShellCommands(private var users: List<String>?) {
         // https://github.com/android/platform_frameworks_base/blob/master/core/java/android/os/UserHandle.java#L123
         val currentUser: Int
             get() {
+                //TODO hg42 another possibility RootFile.cmd("echo \$USER_ID").toInt()
                 try {
                     // using reflection to get id of calling user since method getCallingUserId of UserHandle is hidden
                     // https://github.com/android/platform_frameworks_base/blob/master/core/java/android/os/UserHandle.java#L123

--- a/app/src/main/java/com/machiav3lli/backup/handler/ShellHandler.kt
+++ b/app/src/main/java/com/machiav3lli/backup/handler/ShellHandler.kt
@@ -132,21 +132,18 @@ class ShellHandler(context: Context) {
 
     @Throws(UtilboxNotAvailableException::class)
     fun setUtilBoxPath(utilBoxName: String) {
-        var shellResult = runAsRoot("which $utilBoxName")
-        if (shellResult.out.isNotEmpty()) {
-            utilBoxPath = shellResult.out.joinToString("")
-            if (utilBoxPath.isNotEmpty()) {
-                utilBoxQ = quote(utilBoxPath)
-                shellResult = runAsRoot("$utilBoxQ --version")
-                if (shellResult.out.isNotEmpty()) {
-                    val utilBoxVersion = shellResult.out.joinToString("")
-                    Timber.i("Using Utilbox $utilBoxName : $utilBoxQ : $utilBoxVersion")
-                }
-                return
+        utilBoxQ = quote(utilBoxName)
+        var shellResult = runAsRoot("$utilBoxQ --version")
+        if (shellResult.isSuccess) {
+            if (shellResult.out.isNotEmpty()) {
+                utilBoxVersion = shellResult.out.joinToString("")
+                Timber.i("Using Utilbox $utilBoxName : $utilBoxQ : $utilBoxVersion")
+            } else {
+                Timber.i("Using Utilbox $utilBoxName : $utilBoxQ : no version")
             }
+            return
         }
         // not found => try bare executables (no utilbox prefixed)
-        utilBoxPath = ""
         utilBoxQ = ""
     }
 
@@ -359,9 +356,9 @@ class ShellHandler(context: Context) {
 
     companion object {
 
-        var utilBoxPath = ""
-            private set
         var utilBoxQ = ""
+            private set
+        var utilBoxVersion = ""
             private set
         lateinit var scriptDir : File
             private set

--- a/app/src/main/java/com/machiav3lli/backup/handler/ShellHandler.kt
+++ b/app/src/main/java/com/machiav3lli/backup/handler/ShellHandler.kt
@@ -39,7 +39,6 @@ class ShellHandler {
     lateinit var assets: AssetHandler
 
     init {
-        // TODO: hg42: duplicate to SplashActivity?
         Shell.enableVerboseLogging = BuildConfig.DEBUG
         Shell.setDefaultBuilder(
             Shell.Builder.create()

--- a/app/src/main/java/com/machiav3lli/backup/handler/ShellHandler.kt
+++ b/app/src/main/java/com/machiav3lli/backup/handler/ShellHandler.kt
@@ -121,12 +121,12 @@ class ShellHandler {
         // use -dlZ instead of -dnZ, because -nZ was found (by Kostas!) with an error (with no space between group and context)
         // apparently uid/gid is less tested than names
         var shellResult: Shell.Result? = null
+        val command = "$utilBoxQ ls -bdAlZ ${quote(filepath)}"
         try {
-            val command = "$utilBoxQ ls -bdAlZ ${quote(filepath)}"
             shellResult = runAsRoot(command)
             return shellResult.out[0].split(" ", limit = 6).slice(2..4).toTypedArray()
         } catch (e: Throwable) {
-            throw UnexpectedCommandResult("'\$command' failed", shellResult)
+            throw UnexpectedCommandResult("'$command' failed", shellResult)
         }
     }
 

--- a/app/src/main/java/com/machiav3lli/backup/handler/ShellHandler.kt
+++ b/app/src/main/java/com/machiav3lli/backup/handler/ShellHandler.kt
@@ -17,9 +17,9 @@
  */
 package com.machiav3lli.backup.handler
 
-import android.content.Context
 import android.os.Environment.DIRECTORY_DOCUMENTS
 import com.machiav3lli.backup.BuildConfig
+import com.machiav3lli.backup.OABX
 import com.machiav3lli.backup.activities.MainActivityX.Companion.activity
 import com.machiav3lli.backup.handler.ShellHandler.FileInfo.FileType
 import com.machiav3lli.backup.utils.BUFFER_SIZE
@@ -34,7 +34,7 @@ import java.text.SimpleDateFormat
 import java.util.*
 import java.util.regex.Pattern
 
-class ShellHandler(context: Context) {
+class ShellHandler {
 
     lateinit var assets: AssetHandler
 
@@ -63,7 +63,7 @@ class ShellHandler(context: Context) {
             throw UtilboxNotAvailableException(names.joinToString(", "), null)
         }
 
-        assets = AssetHandler(context)
+        assets = AssetHandler(OABX.context)
         scriptDir = assets.directory
         scriptUserDir = File(
             activity?.getExternalFilesDir(DIRECTORY_DOCUMENTS),

--- a/app/src/main/java/com/machiav3lli/backup/handler/WorkHandler.kt
+++ b/app/src/main/java/com/machiav3lli/backup/handler/WorkHandler.kt
@@ -1,0 +1,47 @@
+package com.machiav3lli.backup.handler
+
+import android.content.Context
+import android.content.IntentFilter
+import androidx.work.WorkManager
+import com.machiav3lli.backup.activities.MainActivityX
+import com.machiav3lli.backup.services.WorkReceiver
+import com.machiav3lli.backup.tasks.AppActionWork
+
+class WorkHandler(context: Context) {
+
+    var manager: WorkManager = WorkManager.getInstance(context)
+    lateinit var actionReceiver: WorkReceiver
+    lateinit var context: Context
+
+    init {
+        actionReceiver = WorkReceiver()
+        context.registerReceiver(actionReceiver, IntentFilter())
+
+        manager.pruneWork()
+
+        // observe AppActionWork
+        manager.getWorkInfosByTagLiveData(
+            AppActionWork::class.qualifiedName!!
+        ).observeForever {
+            MainActivityX.showRunningStatus(manager, it)
+        }
+    }
+
+    fun release(): WorkHandler? {
+        context.unregisterReceiver(actionReceiver)
+        return null
+    }
+
+    fun startBatch() {
+        manager.pruneWork()
+    }
+
+    fun cancel() {
+        //TODO hg42 MainActivityX.activity?.showToast("cancel work queue")
+        AppActionWork::class.qualifiedName?.let {
+            manager.cancelAllWorkByTag(it)
+        }
+        //TODO hg42 MainActivityX.activity?.refreshView()  // why?
+    }
+
+}

--- a/app/src/main/java/com/machiav3lli/backup/items/RootFile.kt
+++ b/app/src/main/java/com/machiav3lli/backup/items/RootFile.kt
@@ -1,5 +1,6 @@
 package com.machiav3lli.backup.items
 
+import com.machiav3lli.backup.OABX
 import com.machiav3lli.backup.handler.ShellHandler
 import com.machiav3lli.backup.handler.ShellHandler.Companion.runAsRoot
 import com.machiav3lli.backup.handler.ShellHandler.Companion.utilBoxQ
@@ -103,6 +104,7 @@ class RootFile internal constructor(file: File) : File(file.absolutePath) {
      * Unsupported
      */
     override fun deleteOnExit() {
+        clearCache()
         throw UnsupportedOperationException("Unsupported RootFile operation")
     }
 
@@ -185,21 +187,21 @@ class RootFile internal constructor(file: File) : File(file.absolutePath) {
 
     var existsCached : Boolean? = null
     override fun exists(): Boolean {
-        if (existsCached == null)
+        if (existsCached == null || ! OABX.prefFlag("cacheRootFileAttributes", false))
             existsCached = cmdBool("[ -e $quoted ]")
         return existsCached!!
     }
 
     var isDirectoryCached : Boolean? = null
     override fun isDirectory(): Boolean {
-        if (isDirectoryCached == null)
+        if (isDirectoryCached == null || ! OABX.prefFlag("cacheRootFileAttributes", false))
             isDirectoryCached = cmdBool("[ -d $quoted ]")
         return isDirectoryCached!!
     }
 
     var isFileCached : Boolean? = null
     override fun isFile(): Boolean  {
-        if (isFileCached == null)
+        if (isFileCached == null || ! OABX.prefFlag("cacheRootFileAttributes", false))
             isFileCached = cmdBool("[ -f $quoted ]")
         return isFileCached!!
     }

--- a/app/src/main/java/com/machiav3lli/backup/items/RootFile.kt
+++ b/app/src/main/java/com/machiav3lli/backup/items/RootFile.kt
@@ -50,10 +50,6 @@ class RootFile internal constructor(file: File) : File(file.absolutePath) {
     constructor(parent: File?, child: String) : this(parent?.absolutePath, child) {}
     constructor(uri: URI) : this(File(uri)) {}
 
-    private fun cmd(c: String): String = ShellUtils.fastCmd(c)
-
-    private fun cmdBool(c: String): Boolean = ShellUtils.fastCmdResult(c)
-
     override fun canExecute(): Boolean = cmdBool("[ -x $quoted ]")
 
     override fun canRead(): Boolean = cmdBool("[ -r $quoted ]")
@@ -460,6 +456,13 @@ class RootFile internal constructor(file: File) : File(file.absolutePath) {
     fun outputStream(): OutputStream = SuFileOutputStream.open(SuFile(this.absolutePath))
 
     companion object {
+
+        fun cmd(c: String): String = ShellUtils.fastCmd(c)
+        fun cmdBool(c: String): Boolean = ShellUtils.fastCmdResult(c)
+        //private fun cmd(c: String): String = ShellHandler.runAsRoot(c).out[0].toString()
+        //private fun cmdBool(c: String): Boolean = ShellHandler.runAsRoot(c).code == 0
+
+
         fun open(pathname: String): File {
             return if (Shell.rootAccess()) RootFile(pathname) else File(pathname)
         }

--- a/app/src/main/java/com/machiav3lli/backup/items/StorageFile.kt
+++ b/app/src/main/java/com/machiav3lli/backup/items/StorageFile.kt
@@ -4,12 +4,10 @@ import android.content.Context
 import android.database.Cursor
 import android.net.Uri
 import android.provider.DocumentsContract
-import androidx.preference.PreferenceManager
+import com.machiav3lli.backup.OABX
 import com.machiav3lli.backup.handler.LogsHandler
 import com.machiav3lli.backup.handler.ShellHandler
-import com.machiav3lli.backup.handler.ShellHandler.Companion.quote
 import com.machiav3lli.backup.utils.*
-import com.topjohnwu.superuser.ShellUtils
 import timber.log.Timber
 import java.io.File
 import java.io.FileNotFoundException
@@ -31,9 +29,7 @@ open class StorageFile {
         this.parent = parent
         this.context = context
         this.uri = uri
-        if (PreferenceManager.getDefaultSharedPreferences(context)
-                .getBoolean("shadowRootFileForSAF", true)
-        ) {
+        if (OABX.prefFlag("shadowRootFileForSAF", true)) {
             fun isValidPath(file: RootFile?): Boolean = file?.let { file.exists() && file.canRead() && file.canWrite() } ?: false
             parent ?: run {
                 file ?: run {

--- a/app/src/main/java/com/machiav3lli/backup/services/ScheduleService.kt
+++ b/app/src/main/java/com/machiav3lli/backup/services/ScheduleService.kt
@@ -53,7 +53,7 @@ open class ScheduleService : Service() {
         super.onCreate()
         this.notificationId = System.currentTimeMillis().toInt()
         showNotification(
-            this,
+            this.baseContext,
             MainActivityX::class.java,
             notificationId,
             String.format(
@@ -63,21 +63,9 @@ open class ScheduleService : Service() {
             "",
             true
         )
-        if (MainActivityX.initShellHandler(this)) {
-            createNotificationChannel()
-            createForegroundInfo()
-            startForeground(notification.hashCode(), this.notification)
-        } else {
-            showNotification(
-                this,
-                MainActivityX::class.java,
-                notificationId,
-                getString(R.string.schedule_failed),
-                getString(R.string.shell_initproblem),
-                false
-            )
-            stopSelf()
-        }
+        createNotificationChannel()
+        createForegroundInfo()
+        startForeground(notification.hashCode(), this.notification)
     }
 
     override fun onDestroy() {
@@ -92,7 +80,7 @@ open class ScheduleService : Service() {
             val action = intent.action
             when (action) {
                 "WORK_CANCEL_SERVICE" -> {
-                    OABX.workHandler.cancelWork()
+                    OABX.work.cancelBatch()
                     stopSelf()
                 }
             }

--- a/app/src/main/java/com/machiav3lli/backup/services/WorkReceiver.kt
+++ b/app/src/main/java/com/machiav3lli/backup/services/WorkReceiver.kt
@@ -1,0 +1,15 @@
+package com.machiav3lli.backup.services
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.machiav3lli.backup.activities.MainActivityX
+
+class WorkReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent?) {
+        when(intent?.action) {
+                "WORK_CANCEL" -> MainActivityX.cancelWork(context)
+                "WORK_CANCEL_SERVICE" -> MainActivityX.cancelWork(context)
+        }
+    }
+}

--- a/app/src/main/java/com/machiav3lli/backup/services/WorkReceiver.kt
+++ b/app/src/main/java/com/machiav3lli/backup/services/WorkReceiver.kt
@@ -3,13 +3,13 @@ package com.machiav3lli.backup.services
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import com.machiav3lli.backup.activities.MainActivityX
+import com.machiav3lli.backup.OABX
 
 class WorkReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent?) {
         when(intent?.action) {
-                "WORK_CANCEL" -> MainActivityX.cancelWork(context)
-                "WORK_CANCEL_SERVICE" -> MainActivityX.cancelWork(context)
+                "WORK_CANCEL" -> OABX.work.cancel()
+                "WORK_CANCEL_SERVICE" -> OABX.work.cancel()
         }
     }
 }

--- a/app/src/main/java/com/machiav3lli/backup/tasks/AppActionWork.kt
+++ b/app/src/main/java/com/machiav3lli/backup/tasks/AppActionWork.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import androidx.work.*
 import com.machiav3lli.backup.MODE_UNSET
+import com.machiav3lli.backup.OABX
 import com.machiav3lli.backup.activities.MainActivityX
 import com.machiav3lli.backup.handler.BackupRestoreHelper
 import com.machiav3lli.backup.handler.LogsHandler
@@ -77,13 +78,11 @@ class AppActionWork(val context: Context, workerParams: WorkerParameters) :
         val packageLabel = appInfo?.packageLabel
             ?: "NONE"
         try {
-            if(isStopped) { //TODO cleanup  || MainActivityX.cancelAllWork) {
-                setOperation("DEL")
-            } else {
+            if(!isStopped) {
 
                 appInfo?.let { ai ->
                     try {
-                        MainActivityX.shellHandlerInstance?.let { shellHandler ->
+                        OABX.shellHandlerInstance?.let { shellHandler ->
                             result = when {
                                 backupBoolean -> {
                                     BackupRestoreHelper.backup(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -315,4 +315,6 @@
     <string name="all_data">Check all data</string>
     <string name="all_apk">Check all APK</string>
     <string name="showDisabled">Disabled apps</string>
+    <string name="schedule">Schedule</string>
+    <string name="finished">finished</string>
 </resources>

--- a/app/src/main/res/xml/preferences_advanced.xml
+++ b/app/src/main/res/xml/preferences_advanced.xml
@@ -48,6 +48,7 @@
         android:summary="@string/prefs_allowdowngrade_summary"
         android:title="@string/prefs_allowdowngrade" />
 
+    <!-- developer settings -->
 
     <androidx.preference.PreferenceCategory
         android:icon="@drawable/ic_force_kill"

--- a/app/src/main/res/xml/preferences_advanced.xml
+++ b/app/src/main/res/xml/preferences_advanced.xml
@@ -102,6 +102,12 @@
         android:summary="unexpected exceptions are caught and output to logcat and app is restarted (needs restart when toggling)"
         android:title="catchUncaughtException" />
 
+    <androidx.preference.CheckBoxPreference
+        android:defaultValue="false"
+        android:key="cacheRootFileAttributes"
+        android:summary="cache some attributes like exists, isDirectory, isFile, saves many shell commands but may fail if external changes happen"
+        android:title="cacheRootFileAttributes" />
+
     <androidx.preference.SeekBarPreference
         android:defaultValue="0"
         android:inputType="number"

--- a/app/src/main/res/xml/preferences_advanced.xml
+++ b/app/src/main/res/xml/preferences_advanced.xml
@@ -109,6 +109,16 @@
         android:title="cacheRootFileAttributes" />
 
     <androidx.preference.SeekBarPreference
+        android:defaultValue="3"
+        android:inputType="number"
+        android:key="maxRetriesPerPackage"
+        android:max="20"
+        android:summary="maximum number of retires per Package per Batch"
+        android:title="maxRetriesPerPackage"
+        app:min="0"
+        app:showSeekBarValue="true" />
+
+    <androidx.preference.SeekBarPreference
         android:defaultValue="0"
         android:inputType="number"
         android:key="delayBeforeRefreshAppInfo"


### PR DESCRIPTION
* use app instead of activity for some globals, for some things like work manager or preferences, contexts go down to the app context anyways
* move such global things like ShellHandler inititalization to the app, because it is created first and an activity is not necessary
* add WorkHandler (move everything related to it, except showRunningNotification for now)
* add AssetHandler and init as early as possible
* fix: avoid which command to find utilBox, just test the version and use the name. Long term it should probably be found to fix the path which is more secure
* fix testing
* add cacheRootFileAttributes to test if limited attribute caching is useful at all (isDirectory is used quite often)
* fix hanging RootFile shadow. Some storage paths tend to hang (e.g. `*/self/*`, reasons are unclear, observed dramatically on emulator). Use only paths that seem to be sane. Set default to disabled. Especially because clear data helps to get it working again, otherwise your lost, because you don't get through to the preferences to change it.
* use own failure count (instead of attempts in WorkInfo), because attempts increase because of other reasons
* improve some error behavior/messages