### PR TITLE
Fix Call Log JSON Restore Duplicates

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/actions/BackupCallLogsJSONAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/BackupCallLogsJSONAction.kt
@@ -65,7 +65,6 @@ object BackupCallLogsJSONAction {
             CallLog.Calls.GEOCODED_LOCATION,
             CallLog.Calls.IS_READ,
             CallLog.Calls.FEATURES,
-            CallLog.Calls.LAST_MODIFIED,
             CallLog.Calls.NUMBER_PRESENTATION,
             CallLog.Calls.PHONE_ACCOUNT_COMPONENT_NAME,
             CallLog.Calls.PHONE_ACCOUNT_ID,
@@ -99,7 +98,6 @@ object BackupCallLogsJSONAction {
                             CallLog.Calls.GEOCODED_LOCATION -> "GEOCODED_LOCATION"
                             CallLog.Calls.IS_READ -> "IS_READ"
                             CallLog.Calls.FEATURES -> "FEATURES"
-                            CallLog.Calls.LAST_MODIFIED -> "LAST_MODIFIED"
                             CallLog.Calls.NUMBER_PRESENTATION -> "NUMBER_PRESENTATION"
                             CallLog.Calls.PHONE_ACCOUNT_COMPONENT_NAME -> "PHONE_ACCOUNT_COMPONENT_NAME"
                             CallLog.Calls.PHONE_ACCOUNT_ID -> "PHONE_ACCOUNT_ID"

--- a/app/src/main/java/com/machiav3lli/backup/actions/RestoreCallLogsJSONAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/RestoreCallLogsJSONAction.kt
@@ -81,7 +81,6 @@ object RestoreCallLogsJSONAction {
                 "GEOCODED_LOCATION" -> CallLog.Calls.GEOCODED_LOCATION
                 "IS_READ" -> CallLog.Calls.IS_READ
                 "FEATURES" -> CallLog.Calls.FEATURES
-                "LAST_MODIFIED" -> CallLog.Calls.LAST_MODIFIED
                 "NUMBER_PRESENTATION" -> CallLog.Calls.NUMBER_PRESENTATION
                 "PHONE_ACCOUNT_COMPONENT_NAME" -> CallLog.Calls.PHONE_ACCOUNT_COMPONENT_NAME
                 "PHONE_ACCOUNT_ID" -> CallLog.Calls.PHONE_ACCOUNT_ID
@@ -122,7 +121,6 @@ object RestoreCallLogsJSONAction {
                             CallLog.Calls.GEOCODED_LOCATION -> "$queryWhere $useName = '${value.replace("'","''")}' AND"
                             CallLog.Calls.IS_READ -> "$queryWhere $useName = $value AND"
                             CallLog.Calls.FEATURES -> "$queryWhere $useName = $value AND"
-                            CallLog.Calls.LAST_MODIFIED -> "$queryWhere $useName = $value AND"
                             CallLog.Calls.NUMBER_PRESENTATION -> "$queryWhere $useName = '${value.replace("'","''")}' AND"
                             CallLog.Calls.PHONE_ACCOUNT_COMPONENT_NAME -> "$queryWhere $useName = '${value.replace("'","''")}' AND"
                             CallLog.Calls.PHONE_ACCOUNT_ID -> "$queryWhere $useName = '${value.replace("'","''")}' AND"


### PR DESCRIPTION
Remove LAST_MODIFIED, because the dialer app automatically updates the cache fields and the LAST_MODIFIED. This was causing duplicate call log entries.