### PR TITLE
!fixup: Fix: Running ScheduleReceiver on reboot (closes #983)

### DIFF
--- a/src/main/java/com/machiav3lli/backup/manager/services/BootReceiver.kt
+++ b/src/main/java/com/machiav3lli/backup/manager/services/BootReceiver.kt
@@ -26,7 +26,7 @@ import org.koin.core.component.KoinComponent
 class BootReceiver : BroadcastReceiver(), KoinComponent {
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action == Intent.ACTION_BOOT_COMPLETED) {
-            Thread { scheduleAlarmsOnce(context) }
+            Thread { scheduleAlarmsOnce(context) }.start()
         } else return
     }
 }


### PR DESCRIPTION
Fixup for f7eaa9d91a0fde24f1a29a5a4c9b0d9557e74926. Thread was never started.
To schedule the alarms, NeoBackup had to be opened at least once.