### PR TITLE
Security audit: harden root shell + crypto, add tests and CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # Gradle dependencies (app + version catalog)
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+
+  # GitHub Actions used by the workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/codacy-analysis.yml
+++ b/.github/workflows/codacy-analysis.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI
@@ -41,6 +41,6 @@ jobs:
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+# CodeQL static analysis for Kotlin/Java sources.
+# Uses build-mode "none" so the analysis does not require provisioning the
+# full Android SDK / Gradle build on the runner.
+name: CodeQL
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '27 4 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (java-kotlin)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: java-kotlin
+          build-mode: none
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:java-kotlin"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,28 +1,52 @@
-# This workflow will build a Java project with Gradle
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+# Builds the app and runs the local JVM unit tests on every push / PR.
+# See: https://docs.github.com/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
 
 name: Main CI Workflow
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
+
+permissions:
+  contents: read
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-    - name: Compile with Gradle
-      run: ./gradlew compileReleaseSources
-    - name: Clean up
-      run: ./gradlew clean
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install required SDK platform
+        run: sdkmanager "platforms;android-36"
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      # Runs the fast JVM unit tests (security-critical quoting / path-traversal /
+      # key-derivation checks) and then compiles the release sources.
+      - name: Run unit tests
+        run: ./gradlew testDebugUnitTest --stacktrace
+
+      - name: Compile release sources
+        run: ./gradlew compileReleaseSources --stacktrace
+
+      - name: Upload unit test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-report
+          path: build/reports/tests/testDebugUnitTest
+          if-no-files-found: ignore

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -133,6 +133,11 @@ android {
             )
         }
     }
+    testOptions {
+        unitTests {
+            isReturnDefaultValues = true
+        }
+    }
 }
 
 composeCompiler {
@@ -206,6 +211,10 @@ dependencies {
     androidTestImplementation(libs.test.runner)
     implementation(libs.test.rules)
     implementation(libs.test.ext)
+
+    // Local JVM unit tests (fast, run in CI without a device) for security-critical
+    // pure logic: shell quoting, command splitting, archive path-traversal, key derivation.
+    testImplementation("junit:junit:4.13.2")
 
     // compose testing
     // Test rules and transitive dependencies:

--- a/src/androidTest/kotlin/tests/Test_CryptoRoundTrip.kt
+++ b/src/androidTest/kotlin/tests/Test_CryptoRoundTrip.kt
@@ -1,0 +1,74 @@
+package tests.tests
+
+import com.machiav3lli.backup.utils.CIPHER_ALGORITHM
+import com.machiav3lli.backup.utils.CryptoSetupException
+import com.machiav3lli.backup.utils.decryptStream
+import com.machiav3lli.backup.utils.encryptStream
+import com.machiav3lli.backup.utils.initIv
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+
+/**
+ * Instrumented round-trip tests for the AES/GCM backup encryption.
+ *
+ * This runs on-device because the streaming GCM cipher relies on the Android
+ * crypto provider (Conscrypt). It verifies the happy-path round-trip, that a wrong
+ * password never recovers the plaintext, that tampering is not silently accepted as
+ * valid plaintext (F8), and that the IV guards added for F7 reject a missing IV.
+ */
+class Test_CryptoRoundTrip {
+
+    private val password = "test-password"
+    private val salt = "test-salt".toByteArray(Charsets.UTF_8)
+    private val plain = "secret backup payload — 1234567890".toByteArray(Charsets.UTF_8)
+
+    private fun encrypt(iv: ByteArray): ByteArray {
+        val bos = ByteArrayOutputStream()
+        bos.encryptStream(password, salt, iv).use { it.write(plain) }
+        return bos.toByteArray()
+    }
+
+    private fun tryDecrypt(cipherText: ByteArray, pw: String, iv: ByteArray): ByteArray? = try {
+        ByteArrayInputStream(cipherText).decryptStream(pw, salt, iv).use { it.readBytes() }
+    } catch (e: Exception) {
+        null
+    }
+
+    @Test
+    fun roundTrip_recoversPlaintext() {
+        val iv = initIv(CIPHER_ALGORITHM)
+        val cipherText = encrypt(iv)
+        val decrypted = tryDecrypt(cipherText, password, iv)
+        assertArrayEquals(plain, decrypted)
+    }
+
+    @Test
+    fun wrongPassword_doesNotRecoverPlaintext() {
+        val iv = initIv(CIPHER_ALGORITHM)
+        val cipherText = encrypt(iv)
+        val decrypted = tryDecrypt(cipherText, "wrong-password", iv)
+        assertFalse(decrypted != null && plain.contentEquals(decrypted))
+    }
+
+    @Test
+    fun tamperedCiphertext_isNotAcceptedAsPlaintext() {
+        val iv = initIv(CIPHER_ALGORITHM)
+        val cipherText = encrypt(iv)
+        cipherText[cipherText.size - 1] = (cipherText[cipherText.size - 1].toInt() xor 0x01).toByte()
+        val decrypted = tryDecrypt(cipherText, password, iv)
+        assertFalse(decrypted != null && plain.contentEquals(decrypted))
+    }
+
+    @Test(expected = CryptoSetupException::class)
+    fun decrypt_withNullIv_throws() {
+        ByteArrayInputStream(ByteArray(0)).decryptStream(password, salt, null)
+    }
+
+    @Test(expected = CryptoSetupException::class)
+    fun encrypt_withNullIv_throws() {
+        ByteArrayOutputStream().encryptStream(password, salt, null)
+    }
+}

--- a/src/main/assets/files/plugin/pause.internal_sh
+++ b/src/main/assets/files/plugin/pause.internal_sh
@@ -37,7 +37,7 @@ if [[ $command == "pre-backup" ]]; then
   # am kill --user $profileid $package
 
   if $suspend; then
-    pm suspend --user $profileid $package >/dev/null
+    pm suspend --user $profileid "$package" >/dev/null
     $utilbox sleep 3
   fi
 
@@ -47,7 +47,7 @@ if [[ $command == "pre-backup" ]]; then
       $utilbox ls -l /proc/*/fd/* 2>/dev/null |
           $utilbox grep -E "/data/data/|/media/" |
           #$utilbox grep -E "/data/|/media/" |  #TODO add an option for wider catching
-          $utilbox grep -F /$package/ |
+          $utilbox grep -F "/$package/" |
           $utilbox cut -s -d / -f 3
     ) |
     $utilbox sort -u -n
@@ -109,7 +109,7 @@ if [[ $command == "post-backup" ]]; then
   if [[ -n $* ]]; then $utilbox kill -CONT "$@"; fi
 
   if $suspend; then
-    pm unsuspend --user $profileid $package
+    pm unsuspend --user $profileid "$package"
   fi
 
   exit
@@ -143,7 +143,7 @@ if [[ $command == "pre-restore" ]]; then
 
     # kill app and all of its services without canceling it's scheduled alarms and jobs.
     # if command does not exist (or fails) stop everything instead
-    am stop-app --user $profileid $package || am force-stop --user $profileid $package
+    am stop-app --user $profileid "$package" || am force-stop --user $profileid "$package"
 
   fi
 

--- a/src/main/assets/files/plugin/tar.internal_sh
+++ b/src/main/assets/files/plugin/tar.internal_sh
@@ -47,6 +47,11 @@ elif [[ $command == "extract" ]]; then
   dir=$1
   shift
 
+  # SECURITY (path traversal / "tar slip"): the util-box tar (toybox/busybox/GNU)
+  # strips leading "/" and rejects ".." path components by default, so extraction
+  # stays within "$dir". Do NOT add GNU-only flags such as --no-absolute-filenames
+  # here: toybox tar does not recognize them and would abort every restore.
+  # The commons-compress based API path enforces the same containment in Kotlin.
   $utilbox tar -x -o -f "$archive" -C "$dir" $exclude
 
   exit $?

--- a/src/main/java/com/machiav3lli/backup/manager/actions/BaseAppAction.kt
+++ b/src/main/java/com/machiav3lli/backup/manager/actions/BaseAppAction.kt
@@ -22,6 +22,7 @@ import android.content.pm.PackageManager
 import com.machiav3lli.backup.manager.handler.LogsHandler
 import com.machiav3lli.backup.manager.handler.ShellCommands.Companion.currentProfile
 import com.machiav3lli.backup.manager.handler.ShellHandler
+import com.machiav3lli.backup.manager.handler.ShellHandler.Companion.quote
 import com.machiav3lli.backup.manager.handler.ShellHandler.Companion.runAsRoot
 import com.machiav3lli.backup.manager.handler.ShellHandler.Companion.utilBoxQ
 import com.machiav3lli.backup.manager.handler.ShellHandler.ShellCommandFailedException
@@ -117,7 +118,7 @@ abstract class BaseAppAction protected constructor(
             }
             val params = stoppedPids?.joinToString("", " ") ?: ""
 
-            val cmd = "sh $script $wh-$type $profileId $utilBoxQ $options $packageName $appuid$params"
+            val cmd = "sh $script $wh-$type $profileId $utilBoxQ $options ${quote(packageName)} $appuid$params"
             traceBold { "$type $packageName: $cmd" }
 
             val shellResult = runAsRoot(cmd)
@@ -186,14 +187,14 @@ abstract class BaseAppAction protected constructor(
 
         fun isSuspended(packageName: String): Boolean {
             val profileId = currentProfile
-            return ShellUtils.fastCmdResult("pm dump --user $profileId $packageName | grep suspended=true")
+            return ShellUtils.fastCmdResult("pm dump --user $profileId ${quote(packageName)} | grep suspended=true")
         }
 
         fun cleanupSuspended(packageName: String) {
             val profileId = currentProfile
             Timber.i("cleanup $packageName")
             try {
-                runAsRoot("pm dump --user $profileId $packageName | grep suspended=true && pm unsuspend --user $profileId ${packageName}")
+                runAsRoot("pm dump --user $profileId ${quote(packageName)} | grep suspended=true && pm unsuspend --user $profileId ${quote(packageName)}")
             } catch (e: Throwable) {
             }
         }

--- a/src/main/java/com/machiav3lli/backup/manager/actions/RestoreAppAction.kt
+++ b/src/main/java/com/machiav3lli/backup/manager/actions/RestoreAppAction.kt
@@ -363,7 +363,7 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
                     .filterNot { it.isEmpty() }
                     .forEach { p ->
                         try {
-                            runAsRoot("pm grant --user $profileId ${backup.packageName} $p")
+                            runAsRoot("pm grant --user $profileId ${quote(backup.packageName)} ${quote(p)}")
                         } catch (e: ShellCommandFailedException) {
                             val details = e.shellResult.err
                                 .joinToString("\n")
@@ -1040,11 +1040,11 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
             "cat", quote(apkFile.absolutePath),
             "|",
             "pm", "install",
-            basePackageName?.let { "-p $basePackageName" },
+            basePackageName?.let { "-p ${quote(it)}" },
             if (isRestoreAllPermissions) "-g" else null,
             if (isAllowDowngrade) "-d" else null,
             if (hasPmBypassLowTargetSDKBlock) "--bypass-low-target-sdk-block" else null,
-            "-i ${pref_installationPackage.value}",
+            "-i ${quote(pref_installationPackage.value)}",
             "-t",
             "-r",
             "-S", apkFile.length(),
@@ -1061,7 +1061,7 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
             if (isRestoreAllPermissions) "-g" else null,
             if (isAllowDowngrade) "-d" else null,
             if (hasPmBypassLowTargetSDKBlock) "--bypass-low-target-sdk-block" else null,
-            "-i", pref_installationPackage.value,
+            "-i", quote(pref_installationPackage.value),
             "-t",
             "-r",
             "-S", sumSize,
@@ -1078,7 +1078,7 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
             "pm", "install-write",
             "-S", apkFile.length(),
             sessionId,
-            apkFile.name,
+            quote(apkFile.name),
         ).joinToString(" ")
 
 

--- a/src/main/java/com/machiav3lli/backup/manager/handler/BackendController.kt
+++ b/src/main/java/com/machiav3lli/backup/manager/handler/BackendController.kt
@@ -40,6 +40,7 @@ import com.machiav3lli.backup.data.preferences.traceTiming
 import com.machiav3lli.backup.data.repository.PackageRepository
 import com.machiav3lli.backup.manager.handler.LogsHandler.Companion.logException
 import com.machiav3lli.backup.manager.handler.ShellCommands.Companion.currentProfile
+import com.machiav3lli.backup.manager.handler.ShellHandler.Companion.quote
 import com.machiav3lli.backup.manager.handler.ShellHandler.Companion.runAsRoot
 import com.machiav3lli.backup.ui.pages.pref_backupSuspendApps
 import com.machiav3lli.backup.ui.pages.pref_createInvalidBackups
@@ -701,7 +702,7 @@ suspend fun Context.updateAppTables() {
                     NeoApp.main?.whileShowingSnackBar(getString(R.string.supended_apps_cleanup)) {
                         // cleanup suspended package if lock file found
                         this.forEach { packageName ->
-                            runAsRoot("pm unsuspend --user $profileId $packageName")
+                            runAsRoot("pm unsuspend --user $profileId ${quote(packageName)}")
                         }
                         NeoApp.appsSuspendedChecked = true
                     }

--- a/src/main/java/com/machiav3lli/backup/manager/handler/ShellCommands.kt
+++ b/src/main/java/com/machiav3lli/backup/manager/handler/ShellCommands.kt
@@ -61,7 +61,7 @@ class ShellCommands {
                 if (!users.isNullOrEmpty()) {
                     val commands = mutableListOf<String>()
                     for (user in users) {
-                        commands.add("pm uninstall --user $user $packageName")
+                        commands.add("pm uninstall --user $user ${quote(packageName.orEmpty())}")
                     }
                     val command = commands.joinToString(" ; ")  // no dependency
                     try {
@@ -79,7 +79,7 @@ class ShellCommands {
                     // don't care for the result here, it likely fails due to file not found
                     try {
                         if (!packageName.isNullOrEmpty()) { // IMPORTANT!!! otherwise removing all in parent(!) directory
-                            val command = "$utilBoxQ rm -rf /data/lib/$packageName/*"
+                            val command = "$utilBoxQ rm -rf ${quote("/data/lib/$packageName")}/*"
                             runAsRoot(command)
                         }
                     } catch (e: ShellCommandFailedException) {
@@ -129,7 +129,7 @@ class ShellCommands {
             if (!users.isNullOrEmpty()) {
                 val commands = mutableListOf<String>()
                 for (user in users) {
-                    commands.add("pm $option --user $user $packageName")
+                    commands.add("pm $option --user $user ${quote(packageName.orEmpty())}")
                 }
                 val command = commands.joinToString(" ; ")  // no dependency
                 try {

--- a/src/main/java/com/machiav3lli/backup/ui/pages/AppPage.kt
+++ b/src/main/java/com/machiav3lli/backup/ui/pages/AppPage.kt
@@ -77,6 +77,7 @@ import com.machiav3lli.backup.exodusUrl
 import com.machiav3lli.backup.manager.handler.ShellCommands
 import com.machiav3lli.backup.manager.handler.ShellCommands.Companion.currentProfile
 import com.machiav3lli.backup.manager.handler.ShellHandler
+import com.machiav3lli.backup.manager.handler.ShellHandler.Companion.quote
 import com.machiav3lli.backup.manager.handler.ShellHandler.Companion.runAsRoot
 import com.machiav3lli.backup.manager.tasks.BackupActionTask
 import com.machiav3lli.backup.manager.tasks.RestoreActionTask
@@ -688,7 +689,7 @@ fun AppPage(
                                     //TODO hg42 force-stop, force-close, ... ? I think these are different ones, and I don't know which.
                                     //TODO hg42 killBackgroundProcesses seems to be am kill
                                     //TODO in api33 A13 there is am stop-app which doesn't kill alarms and
-                                    runAsRoot("am stop-app --user $profileId ${pkg.packageName} || am force-stop --user $profileId ${pkg.packageName}")
+                                    runAsRoot("am stop-app --user $profileId ${quote(pkg.packageName)} || am force-stop --user $profileId ${quote(pkg.packageName)}")
                                 }
                             )
                         }

--- a/src/main/java/com/machiav3lli/backup/utils/CryptoUtils.kt
+++ b/src/main/java/com/machiav3lli/backup/utils/CryptoUtils.kt
@@ -31,7 +31,7 @@ import javax.crypto.*
 import javax.crypto.spec.IvParameterSpec
 import javax.crypto.spec.PBEKeySpec
 import javax.crypto.spec.SecretKeySpec
-import kotlin.random.Random
+import java.security.SecureRandom
 
 /**
  * Crypto. The class to handle encryption and decryption of streams.
@@ -60,8 +60,8 @@ private const val ENCRYPTION_SETUP_FAILED = "Could not setup encryption"
  */
 private const val DEFAULT_SECRET_KEY_FACTORY_ALGORITHM = "PBKDF2withHmacSHA256"
 const val CIPHER_ALGORITHM = "AES/GCM/NoPadding"
-val DEFAULT_IV = ByteArray(Cipher.getInstance(CIPHER_ALGORITHM).blockSize) { 0 }
 private const val DEFAULT_IV_BLOCK_SIZE = 32 // 256 bit
+private const val GCM_NONCE_LENGTH = 12 // 96 bit, recommended nonce size for AES-GCM
 private const val ITERATION_COUNT = 2020
 private const val KEY_LENGTH = 256
 
@@ -105,6 +105,8 @@ fun OutputStream.encryptStream(
     iv: ByteArray?,
     cipherAlgorithm: String = CIPHER_ALGORITHM
 ): CipherOutputStream = try {
+    if (iv == null || iv.isEmpty())
+        throw CryptoSetupException(IllegalArgumentException("Missing IV for encryption"))
     val cipher = Cipher.getInstance(cipherAlgorithm)
     val ivParams = IvParameterSpec(iv)
     cipher.init(Cipher.ENCRYPT_MODE, secret, ivParams)
@@ -139,8 +141,10 @@ fun InputStream.decryptStream(
     iv: ByteArray?,
     cipherAlgorithm: String = CIPHER_ALGORITHM
 ): CipherInputStream = try {
+    if (iv == null || iv.isEmpty())
+        throw CryptoSetupException(IllegalArgumentException("Missing IV for decryption"))
     val cipher = Cipher.getInstance(cipherAlgorithm)
-    val ivParams = IvParameterSpec(iv ?: DEFAULT_IV)
+    val ivParams = IvParameterSpec(iv)
     cipher.init(Cipher.DECRYPT_MODE, secret, ivParams)
     CipherInputStream(this, cipher)
 } catch (e: NoSuchPaddingException) {
@@ -154,7 +158,10 @@ fun InputStream.decryptStream(
 }
 
 fun initIv(cipherAlgorithm: String): ByteArray {
-    val blockSize: Int = try {
+    val size: Int = if (cipherAlgorithm.contains("GCM")) {
+        // AES-GCM: use the recommended 96-bit nonce.
+        GCM_NONCE_LENGTH
+    } else try {
         val cipher = Cipher.getInstance(cipherAlgorithm)
         cipher.blockSize
     } catch (e: NoSuchAlgorithmException) {
@@ -165,7 +172,7 @@ fun initIv(cipherAlgorithm: String): ByteArray {
     } catch (e: NoSuchPaddingException) {
         DEFAULT_IV_BLOCK_SIZE
     }
-    // IV is nothing secret. Could also be constant, but why not spend a few cpu cycles to have
-    // it dynamic, if the algorithm changes?
-    return Random.nextBytes(blockSize)
+    // The IV/nonce is not secret, but for AES-GCM it MUST be unique per key and unpredictable,
+    // so it is generated with a cryptographically secure RNG rather than kotlin.random.Random.
+    return ByteArray(size).also { SecureRandom().nextBytes(it) }
 }

--- a/src/main/java/com/machiav3lli/backup/utils/TarUtils.kt
+++ b/src/main/java/com/machiav3lli/backup/utils/TarUtils.kt
@@ -36,10 +36,42 @@ import java.io.BufferedInputStream
 import java.io.File
 import java.io.FileInputStream
 import java.io.IOException
+import java.nio.file.Paths
 import java.text.SimpleDateFormat
 import java.util.*
 
 const val BUFFER_SIZE = 8 * 1024 * 1024
+
+/**
+ * SECURITY: purely lexical containment check used to defend against archive path
+ * traversal ("tar slip"). Resolves [name] against [baseDir] and returns the resulting
+ * path only if it stays inside [baseDir]. Absolute names and "../" escapes return null.
+ * This is intentionally lexical (it does not touch the filesystem) so it cannot be
+ * fooled by, or accidentally follow, symlinks while running as root.
+ */
+internal fun safeResolveInside(baseDir: File, name: String): File? = try {
+    val base = Paths.get(baseDir.absolutePath).normalize()
+    val resolved = base.resolve(name).normalize()
+    if (resolved == base || resolved.startsWith(base)) File(resolved.toString())
+    else null
+} catch (_: Exception) {
+    null
+}
+
+/**
+ * SECURITY: validates that a link entry's target ([linkName]), resolved relative to the
+ * link's own parent directory, stays inside [baseDir]. Rejecting escaping link targets
+ * prevents the classic tar-slip write-through (create a symlink pointing outside the
+ * target dir, then write a file through it as root).
+ */
+internal fun isLinkTargetInside(baseDir: File, linkFile: File, linkName: String): Boolean = try {
+    val base = Paths.get(baseDir.absolutePath).normalize()
+    val parent = Paths.get(linkFile.absolutePath).normalize().parent ?: base
+    val resolved = parent.resolve(linkName).normalize()
+    resolved == base || resolved.startsWith(base)
+} catch (_: Exception) {
+    false
+}
 
 // octal
 
@@ -196,6 +228,12 @@ fun TarArchiveInputStream.suUnpackTo(targetDir: RootFile, forceOldVersion: Boole
     val strictHardLinks = pref_strictHardLinks.value && !forceOldVersion
     val postponeInfo = mutableMapOf<String, TarArchiveEntry>()
     generateSequence { nextTarEntry }.forEach { tarEntry ->
+        // SECURITY: reject entries whose path escapes targetDir (tar path traversal).
+        // Must run before any mkdir/write/link, since extraction happens as root.
+        if (safeResolveInside(targetDir, tarEntry.name) == null) {
+            Timber.e("Rejecting tar entry escaping target dir: ${tarEntry.name}")
+            return@forEach
+        }
         val targetFile = RootFile(targetDir, tarEntry.name)
         Timber.d("Extracting ${tarEntry.name} (filesize: ${tarEntry.realSize})")
         targetFile.parentFile?.let {
@@ -220,6 +258,11 @@ fun TarArchiveInputStream.suUnpackTo(targetDir: RootFile, forceOldVersion: Boole
                 postponeAttribs = true
             }
             tarEntry.isLink                             -> {
+                // SECURITY: reject links whose target escapes targetDir (tar slip).
+                if (!isLinkTargetInside(targetDir, targetFile, tarEntry.linkName)) {
+                    Timber.e("Rejecting hardlink escaping target dir: ${tarEntry.name} -> ${tarEntry.linkName}")
+                    return@forEach
+                }
                 // OABX v7 tarapi implementation stores all links as hard links (bug)
                 // and extracts all links as symlinks (repair)
                 if (strictHardLinks)
@@ -242,6 +285,11 @@ fun TarArchiveInputStream.suUnpackTo(targetDir: RootFile, forceOldVersion: Boole
                 doAttribs = false
             }
             tarEntry.isSymbolicLink                     -> {
+                // SECURITY: reject symlinks whose target escapes targetDir (tar slip).
+                if (!isLinkTargetInside(targetDir, targetFile, tarEntry.linkName)) {
+                    Timber.e("Rejecting symlink escaping target dir: ${tarEntry.name} -> ${tarEntry.linkName}")
+                    return@forEach
+                }
                 try {
                     runAsRoot(
                         "$qUtilBox ln -s ${quote(tarEntry.linkName)} ${quote(targetFile)}"

--- a/src/test/kotlin/com/machiav3lli/backup/manager/handler/ShellQuotingTest.kt
+++ b/src/test/kotlin/com/machiav3lli/backup/manager/handler/ShellQuotingTest.kt
@@ -1,0 +1,155 @@
+package com.machiav3lli.backup.manager.handler
+
+import com.machiav3lli.backup.manager.handler.ShellHandler.Companion.quote
+import com.machiav3lli.backup.manager.handler.ShellHandler.Companion.splitCommand
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the shell-argument quoting ([quote]) and command splitting
+ * ([splitCommand]) used to build root shell commands. Un-quoted parameters here
+ * are a command-injection risk (see the F3 audit finding), so these tests pin the
+ * escaping behaviour against injection payloads.
+ */
+class ShellQuotingTest {
+
+    /**
+     * Independent model of how a POSIX/mksh shell interprets a double-quoted word:
+     * a backslash escapes the following character, everything else is literal.
+     * Used to prove [quote] is lossless and fully wraps its argument, without
+     * re-using quote()'s own implementation.
+     */
+    private fun shellUnquote(quoted: String): String {
+        assertTrue("must be wrapped in double quotes", quoted.length >= 2)
+        assertEquals('"', quoted.first())
+        assertEquals('"', quoted.last())
+        val inner = quoted.substring(1, quoted.length - 1)
+        val sb = StringBuilder()
+        var i = 0
+        while (i < inner.length) {
+            val c = inner[i]
+            if (c == '\\' && i + 1 < inner.length) {
+                sb.append(inner[i + 1]); i += 2
+            } else {
+                sb.append(c); i++
+            }
+        }
+        return sb.toString()
+    }
+
+    /** Inner content must contain no UNescaped shell-active metacharacter. */
+    private fun assertNoUnescapedMetachars(quoted: String) {
+        val inner = quoted.substring(1, quoted.length - 1)
+        var i = 0
+        while (i < inner.length) {
+            val c = inner[i]
+            if (c == '\\') {
+                i += 2 // skip the escaped char
+                continue
+            }
+            assertFalse("unescaped '$' would allow expansion in: $quoted", c == '$')
+            assertFalse("unescaped backtick would allow substitution in: $quoted", c == '`')
+            assertFalse("unescaped double quote would break out in: $quoted", c == '"')
+            i++
+        }
+    }
+
+    private val payloads = listOf(
+        "com.example.app",
+        "a b c",
+        "a;b|c&d",
+        "\$HOME",
+        "\$(id)",
+        "`id`",
+        "a\"b",
+        "a\\b",
+        "a'b",
+        "*.?[abc]",
+        "x\ny",
+        "x\$(touch /tmp/pwned)y",
+        "x`touch /tmp/pwned`y",
+        "x\";touch /tmp/pwned;\"y",
+        "",
+    )
+
+    @Test
+    fun quote_is_lossless_and_fully_wraps_argument() {
+        for (p in payloads) {
+            assertEquals("round trip failed for [$p]", p, shellUnquote(quote(p)))
+        }
+    }
+
+    @Test
+    fun quote_neutralizes_injection_metacharacters() {
+        for (p in payloads) {
+            assertNoUnescapedMetachars(quote(p))
+        }
+    }
+
+    @Test
+    fun quote_escapes_each_special_character() {
+        assertEquals("\"\\\$HOME\"", quote("\$HOME"))
+        assertEquals("\"a\\\"b\"", quote("a\"b"))
+        assertEquals("\"a\\\\b\"", quote("a\\b"))
+    }
+
+    @Test
+    fun quote_leaves_plain_text_intact_but_wrapped() {
+        assertEquals("\"com.example.app\"", quote("com.example.app"))
+    }
+
+    /**
+     * Regression for the F3 remediation: a package name / permission read from an
+     * untrusted backup .properties file flows unescaped into `runAsRoot("pm ... $pkg")`
+     * style commands (RestoreAppAction, AppPage). Building such a command with quote()
+     * applied to a malicious value must keep the payload as a single inert token that
+     * the shell cannot re-interpret as extra commands.
+     */
+    @Test
+    fun quotedCommand_containsInjectionFromUntrustedPackageName() {
+        val maliciousPkg = "x\$(reboot)`id`;rm -rf /"
+        val perm = "android.permission.CAMERA;wipe"
+
+        // Same shape as the real "pm grant --user 0 <pkg> <perm>" sink.
+        val cmd = "pm grant --user 0 ${quote(maliciousPkg)} ${quote(perm)}"
+        val tokens = splitCommand(cmd)
+
+        // The whole package payload survives as exactly one argument (token index 4),
+        // i.e. it was NOT split into extra shell words/commands.
+        assertEquals(listOf("pm", "grant", "--user", "0", maliciousPkg, perm), tokens)
+
+        // And nothing in the emitted command exposes an unescaped expansion metachar.
+        assertNoUnescapedMetachars(quote(maliciousPkg))
+        assertNoUnescapedMetachars(quote(perm))
+    }
+
+    // ---- splitCommand ----
+
+    @Test
+    fun split_plain_command() {
+        assertEquals(listOf("pm", "install", "x"), splitCommand("pm install x"))
+    }
+
+    @Test
+    fun split_collapses_whitespace() {
+        assertEquals(listOf("a", "b", "c"), splitCommand("a  b\tc"))
+    }
+
+    @Test
+    fun split_double_quoted_group() {
+        assertEquals(listOf("hello world"), splitCommand("\"hello world\""))
+    }
+
+    @Test
+    fun split_single_quoted_group() {
+        assertEquals(listOf("single quoted"), splitCommand("'single quoted'"))
+    }
+
+    @Test
+    fun split_empty_command_is_empty_list() {
+        assertEquals(emptyList<String>(), splitCommand(""))
+        assertEquals(emptyList<String>(), splitCommand("   "))
+    }
+}

--- a/src/test/kotlin/com/machiav3lli/backup/utils/CryptoUtilsTest.kt
+++ b/src/test/kotlin/com/machiav3lli/backup/utils/CryptoUtilsTest.kt
@@ -1,0 +1,66 @@
+package com.machiav3lli.backup.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.nio.charset.StandardCharsets
+
+/**
+ * Unit tests for the parts of CryptoUtils that are provider-independent and run on
+ * the local JVM: password-based key derivation ([generateKeyFromPassword]) and
+ * IV/nonce generation ([initIv]).
+ *
+ * The full AES/GCM encrypt/decrypt round-trip depends on the Android crypto provider
+ * (Conscrypt accepts an IvParameterSpec for GCM, the desktop SunJCE provider does not),
+ * so that is covered by an instrumented test instead.
+ */
+class CryptoUtilsTest {
+
+    private fun salt(s: String) = s.toByteArray(StandardCharsets.UTF_8)
+
+    @Test
+    fun derivedKey_hasExpected256BitAesKey() {
+        val key = generateKeyFromPassword("correct horse", salt("saltvalue"))
+        assertEquals("AES", key.algorithm)
+        assertEquals(32, key.encoded.size) // 256-bit key
+    }
+
+    @Test
+    fun derivedKey_isDeterministicForSameInputs() {
+        val a = generateKeyFromPassword("pw", salt("saltvalue")).encoded
+        val b = generateKeyFromPassword("pw", salt("saltvalue")).encoded
+        assertTrue(a.contentEquals(b))
+    }
+
+    @Test
+    fun derivedKey_dependsOnSalt() {
+        // Rationale for F6: a constant/shared salt lets keys be precomputed across
+        // users/backups. Different salts must yield different keys.
+        val a = generateKeyFromPassword("pw", salt("salt-A")).encoded
+        val b = generateKeyFromPassword("pw", salt("salt-B")).encoded
+        assertFalse(a.contentEquals(b))
+    }
+
+    @Test
+    fun derivedKey_dependsOnPassword() {
+        val a = generateKeyFromPassword("password-A", salt("saltvalue")).encoded
+        val b = generateKeyFromPassword("password-B", salt("saltvalue")).encoded
+        assertFalse(a.contentEquals(b))
+    }
+
+    @Test
+    fun initIv_usesRecommended12ByteNonceForGcm() {
+        // F9: AES-GCM should use a 96-bit (12-byte) nonce.
+        val iv = initIv(CIPHER_ALGORITHM)
+        assertEquals(12, iv.size)
+    }
+
+    @Test
+    fun initIv_producesFreshValues() {
+        // F9: generated with SecureRandom, so two nonces must not collide.
+        val a = initIv(CIPHER_ALGORITHM)
+        val b = initIv(CIPHER_ALGORITHM)
+        assertFalse(a.contentEquals(b))
+    }
+}

--- a/src/test/kotlin/com/machiav3lli/backup/utils/PathTraversalTest.kt
+++ b/src/test/kotlin/com/machiav3lli/backup/utils/PathTraversalTest.kt
@@ -1,0 +1,107 @@
+package com.machiav3lli.backup.utils
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Unit tests for the archive path-traversal ("tar slip") defenses used by
+ * [safeResolveInside] and [isLinkTargetInside] in TarUtils.
+ *
+ * These are pure, filesystem-free lexical checks, so they run as fast local JVM
+ * unit tests. They guard the security-critical restore path that writes as root.
+ */
+class PathTraversalTest {
+
+    private val base = File("/data/user/0/app/restore/pkg")
+
+    // ---- safeResolveInside: entries that stay inside are allowed ----
+
+    @Test
+    fun allows_normal_file() {
+        assertNotNull(safeResolveInside(base, "files/db.sqlite"))
+    }
+
+    @Test
+    fun allows_nested_path() {
+        assertNotNull(safeResolveInside(base, "a/b/c/d.txt"))
+    }
+
+    @Test
+    fun allows_current_dir() {
+        assertNotNull(safeResolveInside(base, "."))
+    }
+
+    @Test
+    fun allows_embedded_dotdot_that_stays_inside() {
+        assertNotNull(safeResolveInside(base, "a/b/../c"))
+    }
+
+    // ---- safeResolveInside: escaping entries are rejected (null) ----
+
+    @Test
+    fun rejects_parent_escape() {
+        assertNull(safeResolveInside(base, "../evil"))
+    }
+
+    @Test
+    fun rejects_deep_parent_escape() {
+        assertNull(safeResolveInside(base, "../../../system/bin/x"))
+    }
+
+    @Test
+    fun rejects_mid_path_escape() {
+        assertNull(safeResolveInside(base, "a/../../etc/passwd"))
+    }
+
+    @Test
+    fun rejects_absolute_path() {
+        assertNull(safeResolveInside(base, "/etc/passwd"))
+    }
+
+    @Test
+    fun rejects_absolute_system_path() {
+        assertNull(safeResolveInside(base, "/data/system/packages.xml"))
+    }
+
+    @Test
+    fun rejects_sibling_prefix_directory() {
+        // Classic string-prefix bug: "pkgEVIL" starts with "pkg" but is a different dir.
+        assertNull(safeResolveInside(base, "../pkgEVIL/x"))
+    }
+
+    // ---- isLinkTargetInside: link targets are validated ----
+
+    @Test
+    fun link_target_inside_is_allowed() {
+        val link = File(base, "files/link")
+        assertTrue(isLinkTargetInside(base, link, "../db/real.db"))
+    }
+
+    @Test
+    fun link_target_same_dir_is_allowed() {
+        val link = File(base, "files/link")
+        assertTrue(isLinkTargetInside(base, link, "sibling"))
+    }
+
+    @Test
+    fun link_target_relative_escape_is_rejected() {
+        val link = File(base, "files/link")
+        assertFalse(isLinkTargetInside(base, link, "../../../../system/x"))
+    }
+
+    @Test
+    fun link_target_absolute_escape_is_rejected() {
+        val link = File(base, "files/link")
+        assertFalse(isLinkTargetInside(base, link, "/system/bin/sh"))
+    }
+
+    @Test
+    fun link_target_into_other_app_is_rejected() {
+        val link = File(base, "files/link")
+        assertFalse(isLinkTargetInside(base, link, "/data/data/other/x"))
+    }
+}


### PR DESCRIPTION
Why

Neo-Backup performs many operations as root and restores archives and encrypted data from backup files, so shell-command construction, archive extraction, and the crypto paths are the highest-risk surface. This PR is the result of a safety audit focused on three areas: root-access code, encryption, and test/dependency hygiene.

What changed

Root command injection (highest impact). Package names and permissions read from a backup's .properties metadata are not charset-validated, yet flowed unquoted into root pm/am shell commands. A crafted backup could therefore run arbitrary commands as root on restore/force-kill. All such values now route through ShellHandler.quote() across ShellCommands, BaseAppAction, BackendController, RestoreAppAction, AppPage, and the pause shell plugin.

Archive path traversal ("tar slip"). On restore, tar entries and link targets are now validated to resolve inside the target directory before any root mkdir/write/ln, closing the classic write-through-outside-target hole (TarUtils.kt).

Crypto. Removed the all-zero IV fallback (encrypt/decrypt now fail loudly on a missing IV) and switched AES-GCM nonce generation to SecureRandom at the recommended 12-byte / 96-bit size instead of kotlin.random.Random (CryptoUtils.kt).

Tests + CI. Added JVM unit tests (path traversal, shell quoting, key derivation) plus an instrumented AES-GCM round-trip / tamper / null-IV test. Modernized the Gradle workflow (targets main, JDK 21, current action versions, and now actually runs the unit tests), and added Dependabot and CodeQL.

Validation note

This environment has no Android SDK, so the Android build was not compiled here. The security-critical logic was instead validated by porting it to standalone JVM harnesses and running attack vectors through a real /bin/sh (traversal and injection payloads are neutralized). The GCM round-trip lives in an instrumented test because it depends on the Android Conscrypt provider. Changes were kept backward-compatible and safe-by-inspection.

Deliberately deferred

A few crypto items were left out because they can only ship safely with an on-device build + restore test, and getting them wrong would make existing encrypted backups unrestorable:

Raise PBKDF2 iterations (currently 2020) and use a random per-install salt (both need per-backup KDF params in metadata + a Room migration).
Enforce AES-GCM authentication end to end (Android's CipherInputStream can swallow tag errors).
Migrate off the EOL androidx.security:security-crypto library.